### PR TITLE
feat(meta-critic): ensure endpoint + lifecycle contract + stale-run guard (#58 #60 #61)

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -405,8 +405,17 @@ def import_bundle(
             is_synthesized=payload.meta_review_run.is_synthesized,
             provider=payload.meta_review_run.provider,
             model=payload.meta_review_run.model,
+            error_code=payload.meta_review_run.error_code,
             error_message=payload.meta_review_run.error_message,
         )
+        if payload.meta_review_run.queued_at is not None:
+            run_data["queued_at"] = payload.meta_review_run.queued_at
+        if payload.meta_review_run.running_at is not None:
+            run_data["running_at"] = payload.meta_review_run.running_at
+        if payload.meta_review_run.completed_at is not None:
+            run_data["completed_at"] = payload.meta_review_run.completed_at
+        if payload.meta_review_run.failed_at is not None:
+            run_data["failed_at"] = payload.meta_review_run.failed_at
         if payload.meta_review_run.created_at is not None:
             run_data["created_at"] = payload.meta_review_run.created_at
         run = models.MetaReviewRun(**run_data)

--- a/backend/app/api/meta_reviews.py
+++ b/backend/app/api/meta_reviews.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.deps import get_db, get_tenant_id
 from app.db import models
-from app.reviews.meta_reviewer import run_meta_review
-from app.schemas.meta_review import MetaReviewCreate, MetaReviewRunRead
+from app.reviews.meta_reviewer import (
+    ensure_meta_review_run,
+    normalize_meta_review_run_state,
+    run_meta_review,
+)
+from app.schemas.meta_review import (
+    MetaReviewCreate,
+    MetaReviewEnsureRead,
+    MetaReviewEnsureRequest,
+    MetaReviewRunRead,
+)
 
 router = APIRouter(prefix="/meta-reviews", tags=["meta-reviews"])
 logger = logging.getLogger(__name__)
@@ -29,22 +39,32 @@ def _load_run(
     )
 
 
+def _ensure_document_version_exists(db: Session, tenant_id: str, document_version_id: int) -> None:
+    version = (
+        db.query(models.DocumentVersion)
+        .filter(
+            models.DocumentVersion.tenant_id == tenant_id,
+            models.DocumentVersion.id == document_version_id,
+        )
+        .first()
+    )
+    if not version:
+        raise HTTPException(status_code=404, detail="Document version not found")
+
+
+def _prepare_run_for_response(run: models.MetaReviewRun) -> models.MetaReviewRun:
+    normalize_meta_review_run_state(run)
+    run.comments.sort(key=lambda item: (-item.rank_score, item.start_offset, item.order_index, item.id))
+    return run
+
+
 @router.post("", response_model=MetaReviewRunRead, status_code=201)
 def create_meta_review(
     payload: MetaReviewCreate,
     db: Session = Depends(get_db),
     tenant_id: str = Depends(get_tenant_id),
 ) -> models.MetaReviewRun:
-    version = (
-        db.query(models.DocumentVersion)
-        .filter(
-            models.DocumentVersion.tenant_id == tenant_id,
-            models.DocumentVersion.id == payload.document_version_id,
-        )
-        .first()
-    )
-    if not version:
-        raise HTTPException(status_code=404, detail="Document version not found")
+    _ensure_document_version_exists(db, tenant_id, payload.document_version_id)
     try:
         run = run_meta_review(
             db=db,
@@ -66,8 +86,42 @@ def create_meta_review(
     loaded = _load_run(db, tenant_id, run.id)
     if not loaded:
         raise HTTPException(status_code=500, detail="Failed to load synthesized run")
-    loaded.comments.sort(key=lambda item: (-item.rank_score, item.start_offset, item.order_index, item.id))
-    return loaded
+    return _prepare_run_for_response(loaded)
+
+
+@router.post("/ensure", response_model=MetaReviewEnsureRead)
+def ensure_meta_review(
+    payload: MetaReviewEnsureRequest,
+    db: Session = Depends(get_db),
+    tenant_id: str = Depends(get_tenant_id),
+) -> dict:
+    _ensure_document_version_exists(db, tenant_id, payload.document_version_id)
+    try:
+        ensured = ensure_meta_review_run(
+            db=db,
+            tenant_id=tenant_id,
+            document_version_id=payload.document_version_id,
+            review_job_id=payload.review_job_id,
+            force=payload.force,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception(
+            "meta_ensure_failed tenant_id=%s document_version_id=%s review_job_id=%s",
+            tenant_id,
+            payload.document_version_id,
+            payload.review_job_id,
+        )
+        raise HTTPException(status_code=503, detail="Meta synthesis failed") from exc
+
+    loaded = _load_run(db, tenant_id, ensured.run.id)
+    if not loaded:
+        raise HTTPException(status_code=500, detail="Failed to load synthesized run")
+
+    run_payload = MetaReviewRunRead.model_validate(_prepare_run_for_response(loaded)).model_dump()
+    run_payload["resolution"] = ensured.resolution
+    return run_payload
 
 
 @router.get("/latest", response_model=MetaReviewRunRead)
@@ -86,12 +140,21 @@ def get_latest_meta_review(
             models.MetaReviewRun.tenant_id == tenant_id,
             models.MetaReviewRun.document_version_id == document_version_id,
         )
-        .order_by(models.MetaReviewRun.id.desc())
     )
     if review_job_id is not None:
-        query = query.filter(models.MetaReviewRun.review_job_id == review_job_id)
+        query = query.filter(models.MetaReviewRun.review_job_id == review_job_id).order_by(
+            models.MetaReviewRun.created_at.desc(),
+            models.MetaReviewRun.id.desc(),
+        )
+    else:
+        # Stale-run guard: prioritize the newest review context first, then recency.
+        # Tie-break order for unscoped latest: review_job_id (desc, NULL last), created_at desc, id desc.
+        query = query.order_by(
+            func.coalesce(models.MetaReviewRun.review_job_id, -1).desc(),
+            models.MetaReviewRun.created_at.desc(),
+            models.MetaReviewRun.id.desc(),
+        )
     run = query.first()
     if not run:
         raise HTTPException(status_code=404, detail="Meta review run not found")
-    run.comments.sort(key=lambda item: (-item.rank_score, item.start_offset, item.order_index, item.id))
-    return run
+    return _prepare_run_for_response(run)

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -309,6 +309,11 @@ def _ensure_schema() -> None:
         _ensure_column(connection, "meta_comments", "assignee", "TEXT")
         _ensure_column(connection, "meta_comments", "due_at", "TEXT")
         _ensure_column(connection, "meta_comments", "rank_score", "REAL DEFAULT 0")
+        _ensure_column(connection, "meta_review_runs", "queued_at", "DATETIME")
+        _ensure_column(connection, "meta_review_runs", "running_at", "DATETIME")
+        _ensure_column(connection, "meta_review_runs", "completed_at", "DATETIME")
+        _ensure_column(connection, "meta_review_runs", "failed_at", "DATETIME")
+        _ensure_column(connection, "meta_review_runs", "error_code", "TEXT")
         connection.execute(
             text("UPDATE review_jobs SET trigger='auto' WHERE trigger IS NULL")
         )
@@ -362,6 +367,36 @@ def _ensure_schema() -> None:
         )
         connection.execute(
             text("UPDATE meta_comments SET rank_score=0 WHERE rank_score IS NULL")
+        )
+        connection.execute(
+            text("UPDATE meta_review_runs SET status='completed' WHERE status IS NULL OR status=''")
+        )
+        connection.execute(
+            text("UPDATE meta_review_runs SET queued_at=created_at WHERE queued_at IS NULL")
+        )
+        connection.execute(
+            text(
+                "UPDATE meta_review_runs SET running_at=COALESCE(running_at, queued_at, created_at) "
+                "WHERE status IN ('running', 'completed', 'failed')"
+            )
+        )
+        connection.execute(
+            text(
+                "UPDATE meta_review_runs SET completed_at=COALESCE(completed_at, created_at) "
+                "WHERE status='completed' AND completed_at IS NULL"
+            )
+        )
+        connection.execute(
+            text(
+                "UPDATE meta_review_runs SET failed_at=COALESCE(failed_at, created_at) "
+                "WHERE status='failed' AND failed_at IS NULL"
+            )
+        )
+        connection.execute(
+            text(
+                "UPDATE meta_review_runs SET error_code='meta_synthesis_failed' "
+                "WHERE status='failed' AND (error_code IS NULL OR error_code='')"
+            )
         )
         connection.commit()
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -148,14 +148,31 @@ class MetaReviewRun(Base):
         Integer, ForeignKey("review_jobs.id", ondelete="SET NULL"), index=True, default=None
     )
     input_hash: Mapped[str] = mapped_column(String(128), index=True)
-    status: Mapped[str] = mapped_column(String(32), default="completed")
+    status: Mapped[str] = mapped_column(String(32), default="queued")
+    queued_at: Mapped[datetime | None] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+    running_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
+    failed_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
     is_synthesized: Mapped[bool] = mapped_column(Boolean, default=True)
     provider: Mapped[str] = mapped_column(String(50), default="openai")
     model: Mapped[str] = mapped_column(String(200), default="gpt-4o-mini")
+    error_code: Mapped[str | None] = mapped_column(String(64), default=None)
     error_message: Mapped[str | None] = mapped_column(String(2000), default=None)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(timezone.utc)
     )
+
+    @property
+    def error_details(self) -> dict | None:
+        if self.status != "failed":
+            return None
+        return {
+            "code": self.error_code or "meta_synthesis_failed",
+            "message": self.error_message or "Meta synthesis failed. Please retry.",
+            "retryable": True,
+        }
 
     review_job: Mapped[ReviewJob | None] = relationship("ReviewJob", back_populates="meta_review_runs")
     comments: Mapped[List["MetaComment"]] = relationship(

--- a/backend/app/reviews/meta_reviewer.py
+++ b/backend/app/reviews/meta_reviewer.py
@@ -6,6 +6,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -41,6 +42,29 @@ PRIORITY_SCORE = {"critical": 4.0, "high": 3.0, "medium": 2.0, "low": 1.0}
 IMPACT_SCORE = {"high": 3.0, "medium": 2.0, "low": 1.0}
 EFFORT_SCORE = {"low": 3.0, "medium": 2.0, "high": 1.0}
 
+META_REVIEW_STATUS_QUEUED = "queued"
+META_REVIEW_STATUS_RUNNING = "running"
+META_REVIEW_STATUS_COMPLETED = "completed"
+META_REVIEW_STATUS_FAILED = "failed"
+META_REVIEW_VALID_STATUSES = {
+    META_REVIEW_STATUS_QUEUED,
+    META_REVIEW_STATUS_RUNNING,
+    META_REVIEW_STATUS_COMPLETED,
+    META_REVIEW_STATUS_FAILED,
+}
+META_REVIEW_RESOLUTION_CREATED = "created"
+META_REVIEW_RESOLUTION_REUSED = "reused"
+META_REVIEW_ERROR_CODE_GENERIC = "meta_synthesis_failed"
+META_REVIEW_ERROR_CODE_INPUT = "meta_input_invalid"
+META_REVIEW_ERROR_CODE_PROVIDER = "meta_provider_unavailable"
+META_REVIEW_GENERIC_ERROR_MESSAGE = "Meta synthesis failed. Please retry."
+MAX_SAFE_META_ERROR_MESSAGE_CHARS = 400
+SENSITIVE_ERROR_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9]{8,}"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)api[_-]?key\s*[:=]\s*[^\s,;]+"),
+]
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +96,19 @@ class MetaDirectiveCandidate:
     contributing_reviewers: list[str]
     source_comments: list[models.Comment]
     is_unsynthesized: bool
+
+
+@dataclass
+class MetaReviewInputContext:
+    comments: list[models.Comment]
+    review_job_id: int | None
+    input_hash: str
+
+
+@dataclass
+class MetaReviewEnsureResult:
+    run: models.MetaReviewRun
+    resolution: str
 
 
 def build_input_hash(comments: list[models.Comment]) -> str:
@@ -483,14 +520,79 @@ def dedupe_directives(candidates: list[MetaDirectiveCandidate]) -> list[MetaDire
     return deduped
 
 
-def run_meta_review(
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _redact_sensitive_segments(message: str) -> str:
+    sanitized = message
+    for pattern in SENSITIVE_ERROR_PATTERNS:
+        sanitized = pattern.sub("[redacted]", sanitized)
+    return sanitized
+
+
+def _sanitize_error_message(message: str | None) -> str:
+    if not message:
+        return META_REVIEW_GENERIC_ERROR_MESSAGE
+    compact = " ".join(message.split())
+    compact = _redact_sensitive_segments(compact).strip()
+    if not compact:
+        return META_REVIEW_GENERIC_ERROR_MESSAGE
+    if len(compact) > MAX_SAFE_META_ERROR_MESSAGE_CHARS:
+        compact = compact[: MAX_SAFE_META_ERROR_MESSAGE_CHARS - 1].rstrip() + "…"
+    return compact
+
+
+def _safe_failure_details(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, ValueError):
+        return META_REVIEW_ERROR_CODE_INPUT, _sanitize_error_message(str(exc))
+    if isinstance(exc, LLMProviderError):
+        return META_REVIEW_ERROR_CODE_PROVIDER, "Meta synthesis provider unavailable. Please retry."
+    return META_REVIEW_ERROR_CODE_GENERIC, META_REVIEW_GENERIC_ERROR_MESSAGE
+
+
+def normalize_meta_review_run_state(run: models.MetaReviewRun) -> models.MetaReviewRun:
+    status = (run.status or META_REVIEW_STATUS_COMPLETED).strip().lower()
+    if status not in META_REVIEW_VALID_STATUSES:
+        status = META_REVIEW_STATUS_FAILED if run.error_message else META_REVIEW_STATUS_COMPLETED
+    run.status = status
+
+    if run.queued_at is None:
+        run.queued_at = run.created_at
+
+    if status in {
+        META_REVIEW_STATUS_RUNNING,
+        META_REVIEW_STATUS_COMPLETED,
+        META_REVIEW_STATUS_FAILED,
+    } and run.running_at is None:
+        run.running_at = run.queued_at or run.created_at
+
+    if status == META_REVIEW_STATUS_COMPLETED and run.completed_at is None:
+        run.completed_at = run.created_at
+    if status != META_REVIEW_STATUS_COMPLETED:
+        run.completed_at = None
+
+    if status == META_REVIEW_STATUS_FAILED:
+        if run.failed_at is None:
+            run.failed_at = run.created_at
+        run.error_code = run.error_code or META_REVIEW_ERROR_CODE_GENERIC
+        run.error_message = _sanitize_error_message(run.error_message)
+    else:
+        run.failed_at = None
+
+    if status != META_REVIEW_STATUS_FAILED:
+        run.error_code = None
+        run.error_message = None
+
+    return run
+
+
+def _resolve_meta_review_input_context(
     db: Session,
     tenant_id: str,
     document_version_id: int,
-    review_job_id: int | None = None,
-    force: bool = False,
-) -> models.MetaReviewRun:
-    started = time.perf_counter()
+    review_job_id: int | None,
+) -> MetaReviewInputContext:
     effective_review_job_id = review_job_id
     query = db.query(models.Comment).filter(
         models.Comment.tenant_id == tenant_id,
@@ -522,61 +624,116 @@ def run_meta_review(
             f"Too many source comments for meta synthesis ({len(comments)} > {MAX_META_COMMENTS_INPUT})"
         )
 
-    input_hash = build_input_hash(comments)
+    return MetaReviewInputContext(
+        comments=comments,
+        review_job_id=effective_review_job_id,
+        input_hash=build_input_hash(comments),
+    )
+
+
+def _find_matching_meta_run(
+    db: Session,
+    tenant_id: str,
+    document_version_id: int,
+    review_job_id: int | None,
+    input_hash: str,
+) -> models.MetaReviewRun | None:
+    run = (
+        db.query(models.MetaReviewRun)
+        .filter(
+            models.MetaReviewRun.tenant_id == tenant_id,
+            models.MetaReviewRun.document_version_id == document_version_id,
+            models.MetaReviewRun.review_job_id == review_job_id,
+            models.MetaReviewRun.input_hash == input_hash,
+        )
+        .order_by(models.MetaReviewRun.created_at.desc(), models.MetaReviewRun.id.desc())
+        .first()
+    )
+    if run:
+        normalize_meta_review_run_state(run)
+    return run
+
+
+def ensure_meta_review_run(
+    db: Session,
+    tenant_id: str,
+    document_version_id: int,
+    review_job_id: int | None = None,
+    force: bool = False,
+) -> MetaReviewEnsureResult:
+    started = time.perf_counter()
+    context = _resolve_meta_review_input_context(db, tenant_id, document_version_id, review_job_id)
+    comments = context.comments
+    effective_review_job_id = context.review_job_id
+    input_hash = context.input_hash
+
     if not force:
-        cached = (
-            db.query(models.MetaReviewRun)
-            .filter(
-                models.MetaReviewRun.tenant_id == tenant_id,
-                models.MetaReviewRun.document_version_id == document_version_id,
-                models.MetaReviewRun.review_job_id == effective_review_job_id,
-                models.MetaReviewRun.input_hash == input_hash,
-            )
-            .order_by(models.MetaReviewRun.id.desc())
-            .first()
+        cached = _find_matching_meta_run(
+            db,
+            tenant_id,
+            document_version_id,
+            effective_review_job_id,
+            input_hash,
         )
         if cached:
-            return cached
+            return MetaReviewEnsureResult(run=cached, resolution=META_REVIEW_RESOLUTION_REUSED)
 
     run = models.MetaReviewRun(
         tenant_id=tenant_id,
         document_version_id=document_version_id,
         review_job_id=effective_review_job_id,
         input_hash=input_hash,
-        status="running",
-        is_synthesized=True,
+        status=META_REVIEW_STATUS_QUEUED,
+        queued_at=_utcnow(),
+        running_at=None,
+        completed_at=None,
+        failed_at=None,
+        is_synthesized=False,
         provider=get_provider_name(),
         model=get_model_label(),
+        error_code=None,
+        error_message=None,
     )
     db.add(run)
     db.flush()
 
-    personas = (
-        db.query(models.Persona)
-        .filter(models.Persona.tenant_id == tenant_id)
-        .order_by(models.Persona.id.asc())
-        .all()
-    )
-    persona_map = {persona.id: persona for persona in personas}
+    run.status = META_REVIEW_STATUS_RUNNING
+    run.running_at = _utcnow()
+    db.commit()
+    db.refresh(run)
 
-    version = (
-        db.query(models.DocumentVersion)
-        .filter(
-            models.DocumentVersion.tenant_id == tenant_id,
-            models.DocumentVersion.id == document_version_id,
-        )
-        .first()
-    )
-    content = version.content if version else ""
-    groups = group_comments_by_location(comments)
-    if len(groups) > MAX_META_GROUPS:
-        raise ValueError(f"Too many comment groups for meta synthesis ({len(groups)} > {MAX_META_GROUPS})")
-
-    synthesized_all = True
-    candidates: list[MetaDirectiveCandidate] = []
-    order_index = 0
+    groups: list[CommentGroup] = []
+    synthesized_all = False
 
     try:
+        personas = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id)
+            .order_by(models.Persona.id.asc())
+            .all()
+        )
+        persona_map = {persona.id: persona for persona in personas}
+
+        version = (
+            db.query(models.DocumentVersion)
+            .filter(
+                models.DocumentVersion.tenant_id == tenant_id,
+                models.DocumentVersion.id == document_version_id,
+            )
+            .first()
+        )
+        content = version.content if version else ""
+
+        groups = group_comments_by_location(comments)
+        if len(groups) > MAX_META_GROUPS:
+            raise ValueError(
+                f"Too many comment groups for meta synthesis ({len(groups)} > {MAX_META_GROUPS})"
+            )
+
+        synthesized_all = True
+        candidates: list[MetaDirectiveCandidate] = []
+        order_index = 0
+
         for group in groups:
             directives, synthesized = synthesize_group(group, persona_map, content)
             synthesized_all = synthesized_all and synthesized
@@ -663,14 +820,33 @@ def run_meta_review(
                     )
                 )
 
-        run.status = "completed"
+        run.status = META_REVIEW_STATUS_COMPLETED
+        run.completed_at = _utcnow()
+        run.failed_at = None
         run.is_synthesized = synthesized_all
+        run.error_code = None
         run.error_message = None
         db.commit()
     except Exception as exc:
-        run.status = "failed"
+        db.rollback()
+        run = (
+            db.query(models.MetaReviewRun)
+            .filter(
+                models.MetaReviewRun.id == run.id,
+                models.MetaReviewRun.tenant_id == tenant_id,
+            )
+            .first()
+        )
+        if run is None:
+            raise
+
+        error_code, error_message = _safe_failure_details(exc)
+        run.status = META_REVIEW_STATUS_FAILED
+        run.failed_at = _utcnow()
+        run.completed_at = None
         run.is_synthesized = False
-        run.error_message = str(exc)
+        run.error_code = error_code
+        run.error_message = error_message
         db.commit()
         logger.exception(
             "meta_review_failed tenant=%s version=%s review_job=%s input_hash=%s error=%s",
@@ -684,10 +860,11 @@ def run_meta_review(
     finally:
         duration_ms = int((time.perf_counter() - started) * 1000)
         logger.info(
-            "meta_review_completed tenant=%s version=%s review_job=%s groups=%s source_comments=%s synthesized=%s duration_ms=%s",
+            "meta_review_completed tenant=%s version=%s review_job=%s status=%s groups=%s source_comments=%s synthesized=%s duration_ms=%s",
             tenant_id,
             document_version_id,
             effective_review_job_id,
+            run.status,
             len(groups),
             len(comments),
             synthesized_all,
@@ -695,4 +872,21 @@ def run_meta_review(
         )
 
     db.refresh(run)
-    return run
+    normalize_meta_review_run_state(run)
+    return MetaReviewEnsureResult(run=run, resolution=META_REVIEW_RESOLUTION_CREATED)
+
+
+def run_meta_review(
+    db: Session,
+    tenant_id: str,
+    document_version_id: int,
+    review_job_id: int | None = None,
+    force: bool = False,
+) -> models.MetaReviewRun:
+    return ensure_meta_review_run(
+        db=db,
+        tenant_id=tenant_id,
+        document_version_id=document_version_id,
+        review_job_id=review_job_id,
+        force=force,
+    ).run

--- a/backend/app/schemas/meta_review.py
+++ b/backend/app/schemas/meta_review.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+MetaReviewStatus = Literal["queued", "running", "completed", "failed"]
+MetaReviewResolution = Literal["reused", "created"]
 
 
 class MetaReviewCreate(BaseModel):
     document_version_id: int = Field(gt=0)
     review_job_id: int | None = Field(default=None, gt=0)
     force: bool = False
+
+
+class MetaReviewEnsureRequest(BaseModel):
+    document_version_id: int = Field(gt=0)
+    review_job_id: int | None = Field(default=None, gt=0)
+    force: bool = False
+
+
+class MetaReviewErrorDetailRead(BaseModel):
+    code: str
+    message: str
+    retryable: bool = True
 
 
 class MetaCommentSourceRead(BaseModel):
@@ -51,12 +67,22 @@ class MetaReviewRunRead(BaseModel):
     document_version_id: int
     review_job_id: int | None
     input_hash: str
-    status: str
+    status: MetaReviewStatus
+    queued_at: datetime | None = None
+    running_at: datetime | None = None
+    completed_at: datetime | None = None
+    failed_at: datetime | None = None
     is_synthesized: bool
     provider: str
     model: str
+    error_code: str | None = None
     error_message: str | None
+    error_details: MetaReviewErrorDetailRead | None = None
     created_at: datetime
     comments: list[MetaCommentRead]
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class MetaReviewEnsureRead(MetaReviewRunRead):
+    resolution: MetaReviewResolution

--- a/backend/app/schemas/review_bundle.py
+++ b/backend/app/schemas/review_bundle.py
@@ -80,9 +80,14 @@ class BundleMetaComment(BaseModel):
 
 class BundleMetaReviewRun(BaseModel):
     status: str = "completed"
+    queued_at: datetime | None = None
+    running_at: datetime | None = None
+    completed_at: datetime | None = None
+    failed_at: datetime | None = None
     is_synthesized: bool = True
     provider: str = "import"
     model: str = "bundle"
+    error_code: str | None = None
     error_message: str | None = None
     created_at: datetime | None = None
     comments: list[BundleMetaComment] = Field(default_factory=list)

--- a/backend/tests/test_meta_reviews.py
+++ b/backend/tests/test_meta_reviews.py
@@ -3,7 +3,13 @@ import json
 from app.reviews.meta_reviewer import group_comments_by_location
 
 
-def _seed_review_data(client, headers):
+def _seed_review_data(client, headers, monkeypatch=None):
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            "app.api.review_jobs.enqueue_review_job",
+            lambda _job_id, _tenant_id: None,
+        )
+
     persona_a = client.post(
         "/api/personas",
         json={
@@ -70,9 +76,46 @@ def _seed_review_data(client, headers):
     return version, job
 
 
+def _add_comments_for_job(
+    client,
+    headers,
+    *,
+    document_version_id: int,
+    review_job_id: int,
+    persona_id_a: int,
+    persona_id_b: int,
+) -> None:
+    client.post(
+        "/api/comments",
+        json={
+            "document_version_id": document_version_id,
+            "review_job_id": review_job_id,
+            "persona_id": persona_id_a,
+            "text": "Clarify latest intent for this review context.",
+            "start_offset": 0,
+            "end_offset": 14,
+            "excerpt": "alpha beta",
+        },
+        headers=headers,
+    )
+    client.post(
+        "/api/comments",
+        json={
+            "document_version_id": document_version_id,
+            "review_job_id": review_job_id,
+            "persona_id": persona_id_b,
+            "text": "Security detail remains vague in latest context.",
+            "start_offset": 12,
+            "end_offset": 30,
+            "excerpt": "beta gamma delta",
+        },
+        headers=headers,
+    )
+
+
 def test_meta_review_create_and_cache(client, monkeypatch) -> None:
     headers = {"X-Tenant-Id": "tenant-meta"}
-    version, job = _seed_review_data(client, headers)
+    version, job = _seed_review_data(client, headers, monkeypatch)
 
     llm_payload = [
         {
@@ -106,7 +149,14 @@ def test_meta_review_create_and_cache(client, monkeypatch) -> None:
     assert create_resp.status_code == 201
     body = create_resp.json()
     assert body["status"] == "completed"
+    assert body["queued_at"] is not None
+    assert body["running_at"] is not None
+    assert body["completed_at"] is not None
+    assert body["failed_at"] is None
     assert body["is_synthesized"] is True
+    assert body["error_code"] is None
+    assert body["error_message"] is None
+    assert body["error_details"] is None
     assert len(body["comments"]) == 1
     assert body["comments"][0]["priority"] == "high"
     assert body["comments"][0]["impact"] == "high"
@@ -131,9 +181,247 @@ def test_meta_review_create_and_cache(client, monkeypatch) -> None:
     assert latest_resp.json()["id"] == body["id"]
 
 
+def test_latest_meta_review_prefers_newest_review_context_over_stale_created_later(
+    client,
+    monkeypatch,
+) -> None:
+    headers = {"X-Tenant-Id": "tenant-meta-latest-guard"}
+    version, older_job = _seed_review_data(client, headers, monkeypatch)
+
+    personas_resp = client.get("/api/personas", headers=headers)
+    assert personas_resp.status_code == 200
+    personas = {item["name"]: item for item in personas_resp.json()}
+    assert "A" in personas and "B" in personas
+
+    newer_job_resp = client.post(
+        "/api/review-jobs",
+        json={"document_version_id": version["id"], "trigger": "manual"},
+        headers=headers,
+    )
+    assert newer_job_resp.status_code == 201
+    newer_job = newer_job_resp.json()
+
+    _add_comments_for_job(
+        client,
+        headers,
+        document_version_id=version["id"],
+        review_job_id=newer_job["id"],
+        persona_id_a=personas["A"]["id"],
+        persona_id_b=personas["B"]["id"],
+    )
+
+    monkeypatch.setattr(
+        "app.reviews.meta_reviewer.generate_completion",
+        lambda _: json.dumps(
+            [
+                {
+                    "content": "Specify exact token validation and expiry requirements.",
+                    "category": "security",
+                    "priority": "high",
+                    "impact": "high",
+                    "effort": "medium",
+                    "confidence": 0.9,
+                    "why_now": "Ambiguity can lead to insecure implementation.",
+                    "recommended_change": "Document explicit checks and expiry behavior.",
+                    "verification_step": "Re-run review to confirm security clarity.",
+                    "status": "open",
+                    "assignee": None,
+                    "due_at": None,
+                    "contributing_reviewers": ["A", "B"],
+                    "location": {"start_offset": 0, "end_offset": 30},
+                }
+            ]
+        ),
+    )
+
+    newer_run_resp = client.post(
+        "/api/meta-reviews",
+        json={"document_version_id": version["id"], "review_job_id": newer_job["id"], "force": True},
+        headers=headers,
+    )
+    assert newer_run_resp.status_code == 201
+    newer_run = newer_run_resp.json()
+
+    stale_run_resp = client.post(
+        "/api/meta-reviews",
+        json={"document_version_id": version["id"], "review_job_id": older_job["id"], "force": True},
+        headers=headers,
+    )
+    assert stale_run_resp.status_code == 201
+    stale_run = stale_run_resp.json()
+    assert stale_run["review_job_id"] == older_job["id"]
+    assert stale_run["id"] != newer_run["id"]
+
+    latest_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}",
+        headers=headers,
+    )
+    assert latest_resp.status_code == 200
+    latest = latest_resp.json()
+    assert latest["review_job_id"] == newer_job["id"]
+    assert latest["id"] == newer_run["id"]
+
+
+def test_latest_meta_review_for_same_context_uses_created_order_tiebreak(client, monkeypatch) -> None:
+    headers = {"X-Tenant-Id": "tenant-meta-latest-tiebreak"}
+    version, job = _seed_review_data(client, headers, monkeypatch)
+
+    monkeypatch.setattr(
+        "app.reviews.meta_reviewer.generate_completion",
+        lambda _: json.dumps(
+            [
+                {
+                    "content": "Clarify authentication and access-control boundaries.",
+                    "category": "security",
+                    "priority": "high",
+                    "impact": "high",
+                    "effort": "low",
+                    "confidence": 0.85,
+                    "why_now": "Reviewers flagged ambiguity in control boundaries.",
+                    "recommended_change": "Name each auth check and expected behavior.",
+                    "verification_step": "Confirm both reviewers no longer raise ambiguity.",
+                    "status": "open",
+                    "assignee": None,
+                    "due_at": None,
+                    "contributing_reviewers": ["A", "B"],
+                    "location": {"start_offset": 0, "end_offset": 28},
+                }
+            ]
+        ),
+    )
+
+    first_resp = client.post(
+        "/api/meta-reviews",
+        json={"document_version_id": version["id"], "review_job_id": job["id"], "force": True},
+        headers=headers,
+    )
+    assert first_resp.status_code == 201
+    first = first_resp.json()
+
+    second_resp = client.post(
+        "/api/meta-reviews",
+        json={"document_version_id": version["id"], "review_job_id": job["id"], "force": True},
+        headers=headers,
+    )
+    assert second_resp.status_code == 201
+    second = second_resp.json()
+    assert second["id"] != first["id"]
+
+    latest_by_job_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}&review_job_id={job['id']}",
+        headers=headers,
+    )
+    assert latest_by_job_resp.status_code == 200
+    latest_by_job = latest_by_job_resp.json()
+    assert latest_by_job["id"] == second["id"]
+
+    latest_unscoped_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}",
+        headers=headers,
+    )
+    assert latest_unscoped_resp.status_code == 200
+    latest_unscoped = latest_unscoped_resp.json()
+    assert latest_unscoped["id"] == second["id"]
+
+
+def test_meta_review_ensure_endpoint_is_idempotent_with_resolution(client, monkeypatch) -> None:
+    headers = {"X-Tenant-Id": "tenant-meta-ensure"}
+    version, job = _seed_review_data(client, headers, monkeypatch)
+
+    monkeypatch.setattr(
+        "app.reviews.meta_reviewer.generate_completion",
+        lambda _: json.dumps(
+            [
+                {
+                    "content": "Clarify auth flow and explicit token lifecycle.",
+                    "category": "security",
+                    "priority": "high",
+                    "impact": "high",
+                    "effort": "low",
+                    "confidence": 0.88,
+                    "why_now": "Current wording could cause insecure implementations.",
+                    "recommended_change": "Define validation and token expiry behavior.",
+                    "verification_step": "Confirm security review comments converge to one directive.",
+                    "status": "open",
+                    "assignee": None,
+                    "due_at": None,
+                    "contributing_reviewers": ["A", "B"],
+                    "location": {"start_offset": 0, "end_offset": 28},
+                }
+            ]
+        ),
+    )
+
+    first_resp = client.post(
+        "/api/meta-reviews/ensure",
+        json={"document_version_id": version["id"], "review_job_id": job["id"]},
+        headers=headers,
+    )
+    assert first_resp.status_code == 200
+    first = first_resp.json()
+    assert first["resolution"] == "created"
+    assert first["status"] == "completed"
+
+    second_resp = client.post(
+        "/api/meta-reviews/ensure",
+        json={"document_version_id": version["id"], "review_job_id": job["id"]},
+        headers=headers,
+    )
+    assert second_resp.status_code == 200
+    second = second_resp.json()
+    assert second["resolution"] == "reused"
+    assert second["id"] == first["id"]
+
+    forced_resp = client.post(
+        "/api/meta-reviews/ensure",
+        json={"document_version_id": version["id"], "review_job_id": job["id"], "force": True},
+        headers=headers,
+    )
+    assert forced_resp.status_code == 200
+    forced = forced_resp.json()
+    assert forced["resolution"] == "created"
+    assert forced["id"] != first["id"]
+
+
+def test_meta_review_failed_run_exposes_safe_error_details(client, monkeypatch) -> None:
+    headers = {"X-Tenant-Id": "tenant-meta-failed"}
+    version, job = _seed_review_data(client, headers, monkeypatch)
+
+    def _raise_failure(*_args, **_kwargs):
+        raise RuntimeError("provider crash sk-live-secret-token")
+
+    monkeypatch.setattr("app.reviews.meta_reviewer.synthesize_group", _raise_failure)
+
+    ensure_resp = client.post(
+        "/api/meta-reviews/ensure",
+        json={"document_version_id": version["id"], "review_job_id": job["id"], "force": True},
+        headers=headers,
+    )
+    assert ensure_resp.status_code == 503
+
+    latest_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}&review_job_id={job['id']}",
+        headers=headers,
+    )
+    assert latest_resp.status_code == 200
+    latest = latest_resp.json()
+    assert latest["status"] == "failed"
+    assert latest["queued_at"] is not None
+    assert latest["running_at"] is not None
+    assert latest["completed_at"] is None
+    assert latest["failed_at"] is not None
+    assert latest["error_code"] == "meta_synthesis_failed"
+    assert latest["error_message"] == "Meta synthesis failed. Please retry."
+    assert latest["error_details"]["code"] == "meta_synthesis_failed"
+    assert latest["error_details"]["message"] == "Meta synthesis failed. Please retry."
+    assert latest["error_details"]["retryable"] is True
+    assert "sk-live" not in latest["error_message"]
+
+
+
 def test_meta_review_fallback_unsynthesized(client, monkeypatch) -> None:
     headers = {"X-Tenant-Id": "tenant-meta-fallback"}
-    version, job = _seed_review_data(client, headers)
+    version, job = _seed_review_data(client, headers, monkeypatch)
     monkeypatch.setattr(
         "app.reviews.meta_reviewer.generate_completion",
         lambda _: "not-json-response",
@@ -145,6 +433,11 @@ def test_meta_review_fallback_unsynthesized(client, monkeypatch) -> None:
     )
     assert resp.status_code == 201
     body = resp.json()
+    assert body["status"] == "completed"
+    assert body["queued_at"] is not None
+    assert body["running_at"] is not None
+    assert body["completed_at"] is not None
+    assert body["failed_at"] is None
     assert body["is_synthesized"] is False
     assert len(body["comments"]) >= 1
     assert any(comment["is_unsynthesized"] for comment in body["comments"])
@@ -166,7 +459,7 @@ def test_grouping_by_location_merges_adjacent() -> None:
 
 def test_meta_review_guardrail_too_many_comments(client, monkeypatch) -> None:
     headers = {"X-Tenant-Id": "tenant-meta-guardrail"}
-    version, job = _seed_review_data(client, headers)
+    version, job = _seed_review_data(client, headers, monkeypatch)
     monkeypatch.setattr("app.reviews.meta_reviewer.MAX_META_COMMENTS_INPUT", 1)
     resp = client.post(
         "/api/meta-reviews",
@@ -178,7 +471,7 @@ def test_meta_review_guardrail_too_many_comments(client, monkeypatch) -> None:
 
 def test_meta_review_falls_back_when_selected_review_job_has_no_comments(client, monkeypatch) -> None:
     headers = {"X-Tenant-Id": "tenant-meta-fallback-job"}
-    version, job = _seed_review_data(client, headers)
+    version, job = _seed_review_data(client, headers, monkeypatch)
     later_job = client.post(
         "/api/review-jobs",
         json={"document_version_id": version["id"], "trigger": "manual"},


### PR DESCRIPTION
## Summary\n- add idempotent meta ensure orchestration endpoint\n- standardize meta lifecycle state contract + timestamps + safe failed-run details\n- add stale-run guard for latest selection to prefer newest review context\n- keep existing meta endpoints backward-compatible\n- add/expand regression tests for idempotency, lifecycle, and latest-selection ordering\n\n## Validation\n- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_meta_reviews.py tests/test_comments_and_reviews.py tests/test_review_queue.py\n- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/api/meta_reviews.py app/reviews/meta_reviewer.py app/db/models.py app/schemas/meta_review.py app/schemas/review_bundle.py tests/test_meta_reviews.py\n\nCloses #58\nCloses #60\nCloses #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/ensure` endpoint for meta-reviews supporting idempotent creation and reuse
  * Meta-review runs now display complete lifecycle status (queued, running, completed, failed) with timestamps
  * Enhanced error details in responses including specific error codes and messages for failed runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->