### PR TITLE
docs(release): add v0.2.0-m1 rollout/rollback/communications pack (#69)

### DIFF
--- a/docs/releases/v0.2.0-m1-rollout-pack.md
+++ b/docs/releases/v0.2.0-m1-rollout-pack.md
@@ -1,0 +1,146 @@
+# v0.2.0-m1 Rollout / Rollback / Communications Pack
+
+Last updated: 2026-03-03 UTC
+Tracking issue: https://github.com/jonzobrist/OpinionatedDocReviewer/issues/69
+Milestone: `M1 Meta-first UX + synthesis orchestration`
+
+## 1) Release scope map (issues #58-#69)
+
+### A) Backend chain delivered (merged)
+
+| Issue | Outcome | Delivered by |
+|---|---|---|
+| [#58](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/58) | Closed | [PR #71](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/71) |
+| [#59](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/59) | Closed | [PR #72](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/72) |
+| [#60](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/60) | Closed | [PR #71](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/71) |
+| [#61](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/61) | Closed | [PR #71](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/71) |
+| [#67](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/67) | Closed | [PR #73](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/73) |
+
+### B) Remaining open M1 scope
+
+| Issue | Scope | Current state |
+|---|---|---|
+| [#62](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/62) | Frontend meta-default mode | `state:in-progress` |
+| [#63](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/63) | Frontend lifecycle state UX | `state:in-progress` |
+| [#64](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/64) | Directive drill-down traceability | `open` |
+| [#65](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/65) | URL state persistence | `state:in-progress` |
+| [#66](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/66) | Bounded polling | `open` |
+| [#68](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/68) | Frontend regression coverage | `open` |
+| [#69](https://github.com/jonzobrist/OpinionatedDocReviewer/issues/69) | Docs/ops rollout pack + release comms | `state:in-progress` (handoff to review in this PR) |
+
+## 2) Go / No-Go checklist (must match branch protection contexts)
+
+### Required checks (exact contexts)
+- [ ] `backend`
+- [ ] `frontend`
+- [ ] `dependency-review`
+- [ ] `backend-audit`
+- [ ] `frontend-audit`
+
+### Release gate checks
+- [ ] All M1 release-scope PRs merged (or explicitly deferred and documented).
+- [ ] No unresolved P0/P1 blockers tied to release scope.
+- [ ] Branch protection + CODEOWNER enforcement still active on `main`.
+- [ ] Release notes draft reviewed for user-visible changes and limitations.
+
+## 3) Deployment sequence (operator steps)
+
+### Pre-deploy
+1. Confirm release SHA on `main`.
+2. Verify required checks are green for the release SHA.
+3. Confirm rollback target tag/SHA (previous known-good).
+
+### Deploy
+```bash
+cd /home/zob/src/OpinionatedDocReviewer
+./scripts/admin/stop.sh
+./scripts/admin/start.sh
+./scripts/admin/status.sh
+./scripts/admin/test.sh
+```
+
+### Tag
+```bash
+cd /home/zob/src/OpinionatedDocReviewer
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git tag -a v0.2.0-m1 -m "M1 meta-first UX + synthesis orchestration"
+git push origin v0.2.0-m1
+```
+
+## 4) Rollback sequence (operator steps)
+
+1. Identify previous stable tag/SHA.
+2. Redeploy previous stable revision.
+3. Restart services and validate smoke tests.
+
+```bash
+cd /home/zob/src/OpinionatedDocReviewer
+git fetch origin
+git checkout <previous-stable-tag-or-sha>
+./scripts/admin/stop.sh
+./scripts/admin/start.sh
+./scripts/admin/status.sh
+./scripts/admin/test.sh
+```
+
+Post-rollback:
+- Log impacted issue/PR IDs and timestamps.
+- Publish incident summary + next corrective actions.
+
+## 5) Communication templates
+
+### A) Casual minor update (Discord/Slack)
+```text
+M1 rollout update: backend chain is merged (#70-#73) and we’re finishing frontend/docs gates.
+Current focus: close remaining M1 items (#62/#63/#64/#65/#66/#68/#69) and validate release checks.
+Next update: <time/date>.
+```
+
+### B) Formal OSS major-style release note (sectioned)
+```markdown
+# OpinionatedDocReviewer v0.2.0-m1
+
+## Summary
+<short release summary>
+
+## Highlights
+- <highlight>
+- <highlight>
+- <highlight>
+
+## Scope
+Merged backend chain: #58 #59 #60 #61 #67 via PRs #71 #72 #73 (+ governance PR #70).
+Open/deferred at cut (if any): #62 #63 #64 #65 #66 #68 #69.
+
+## Security / Governance
+- Branch protection with required checks enforced
+- CODEOWNER review requirement enabled
+- Governance templates/workflows in place
+
+## Rollout Notes
+- <operator note>
+- <operator note>
+
+## Validation Evidence
+- Required checks: backend, frontend, dependency-review, backend-audit, frontend-audit
+- <workflow run links>
+
+## Known Limitations / Deferred
+- <item>
+
+## Rollback
+- Roll back to `<tag-or-sha>` using this rollout pack.
+```
+
+## 6) Known limitations / deferred items template
+
+| Item | Link (issue/PR) | User impact | Mitigation | Planned milestone |
+|---|---|---|---|---|
+| <deferred item> | <#issue/#pr> | <low/medium/high> | <workaround> | <M2/M3/...> |
+| <deferred item> | <#issue/#pr> | <low/medium/high> | <workaround> | <M2/M3/...> |
+
+---
+
+Owner note: keep this document synchronized with issue #69 until M1 cut is finalized.


### PR DESCRIPTION
## Summary
Adds the M1 docs/ops release artifact for rollout execution.

### Included
- `docs/releases/v0.2.0-m1-rollout-pack.md`
  - release scope map for issues #58-#69
  - backend chain delivered summary (#70-#73 context + #71/#72/#73 delivery links)
  - open remaining M1 scope (#62/#63/#64/#65/#66/#68/#69)
  - go/no-go checklist with exact required check contexts
  - deployment and rollback operator steps
  - communication templates (casual + formal OSS sectioned)
  - known limitations/deferred template

Closes #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive rollout documentation for v0.2.0-m1 including release scope overview, Go/No-Go deployment checklist, step-by-step deployment and rollback procedures, communication templates, and known limitations reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->