### PR TITLE
feat(frontend): default meta mode and explicit meta state UX (#62, #63)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,6 +55,7 @@ const AGENT_COLORS = ['#1d8a7a', '#2d6eea', '#b7482f', '#7a4bd3', '#c57a1b', '#0
 
 type DocSegment = { text: string; comment?: CommentRead };
 type ConnectorPath = { id: string; path: string; color: string };
+type MetaViewState = 'idle' | 'loading' | 'ready' | 'pending' | 'missing' | 'error';
 type AgentDraft = {
   name: string;
   description: string;
@@ -169,7 +170,10 @@ function HomePageContent() {
   const [selectedVersionId, setSelectedVersionId] = useState<number | null>(null);
   const [selectedReviewJobId, setSelectedReviewJobId] = useState<number | null>(null);
   const [docMode, setDocMode] = useState<'view' | 'source'>('view');
-  const [commentViewMode, setCommentViewMode] = useState<'individual' | 'meta'>('individual');
+  const [commentViewMode, setCommentViewMode] = useState<'individual' | 'meta'>('meta');
+  const [commentModeSelectionSource, setCommentModeSelectionSource] = useState<'auto' | 'manual'>(
+    'auto'
+  );
   const [focusedCommentId, setFocusedCommentId] = useState<number | null>(null);
   const [hoveredCommentId, setHoveredCommentId] = useState<number | null>(null);
   const [focusedMetaCommentId, setFocusedMetaCommentId] = useState<number | null>(null);
@@ -182,6 +186,7 @@ function HomePageContent() {
   const [recentCommentIds, setRecentCommentIds] = useState<Set<number>>(new Set());
   const [agentThemes, setAgentThemes] = useState<Record<string, AgentTheme>>({});
   const [metaReviewRun, setMetaReviewRun] = useState<MetaReviewRunRead | null>(null);
+  const [metaViewState, setMetaViewState] = useState<MetaViewState>('idle');
   const [isMetaLoading, setIsMetaLoading] = useState(false);
   const [metaCategoryFilter, setMetaCategoryFilter] = useState<
     'all' | 'structure' | 'clarity' | 'technical' | 'security' | 'accessibility' | 'style'
@@ -329,15 +334,26 @@ function HomePageContent() {
 
   useEffect(() => {
     setMetaReviewRun(null);
-    setCommentViewMode('individual');
+    setMetaViewState('idle');
+    setCommentModeSelectionSource('auto');
+    setCommentViewMode('meta');
     setMetaCategoryFilter('all');
   }, [selectedVersionId, selectedReviewJobId]);
 
   useEffect(() => {
     if (commentViewMode !== 'meta') return;
     if (!selectedVersionId) return;
-    void loadOrCreateMetaReview(selectedVersionId, selectedReviewJobId, false);
-  }, [commentViewMode, selectedVersionId, selectedReviewJobId]);
+    void loadOrCreateMetaReview(selectedVersionId, selectedReviewJobId, false, {
+      fallbackToIndividualOnMissing: commentModeSelectionSource === 'auto',
+      reviewJobStatus: selectedReviewJob?.status ?? null
+    });
+  }, [
+    commentViewMode,
+    selectedVersionId,
+    selectedReviewJobId,
+    selectedReviewJob?.status,
+    commentModeSelectionSource
+  ]);
 
   useEffect(() => {
     if (!focusedCommentId) return;
@@ -693,9 +709,14 @@ function HomePageContent() {
   async function loadOrCreateMetaReview(
     versionId: number,
     reviewJobId?: number | null,
-    force = false
+    force = false,
+    options?: {
+      fallbackToIndividualOnMissing?: boolean;
+      reviewJobStatus?: string | null;
+    }
   ) {
     setIsMetaLoading(true);
+    setMetaViewState('loading');
     try {
       if (!force) {
         const query = reviewJobId
@@ -704,11 +725,24 @@ function HomePageContent() {
         try {
           const latest = await apiFetch<MetaReviewRunRead>(query);
           setMetaReviewRun(latest);
-          setStatusMessage(
-            latest.comments.length > 0
-              ? `Meta review loaded (${latest.comments.length} directives).`
-              : 'No meta directives yet. Run review first, then recompute meta.'
-          );
+          if (isMetaSynthesisPendingStatus(latest.status)) {
+            setMetaViewState('pending');
+            setStatusMessage('Meta directives are still being synthesized.');
+          } else if (isMetaSynthesisFailedStatus(latest.status)) {
+            setMetaViewState('error');
+            setStatusMessage(
+              latest.error_message
+                ? `Meta synthesis failed: ${latest.error_message}`
+                : 'Meta synthesis failed. Recompute to retry.'
+            );
+          } else {
+            setMetaViewState('ready');
+            setStatusMessage(
+              latest.comments.length > 0
+                ? `Meta review loaded (${latest.comments.length} directives).`
+                : 'Meta review loaded (no directives).'
+            );
+          }
           return latest;
         } catch (error) {
           const message = normalizeError(error);
@@ -720,8 +754,26 @@ function HomePageContent() {
           if (!missingMetaRun) {
             throw error;
           }
+
+          setMetaReviewRun(null);
+          const synthesisPending = isMetaSynthesisPendingStatus(options?.reviewJobStatus);
+          if (synthesisPending) {
+            setMetaViewState('pending');
+            setStatusMessage('Meta directives are pending while the active review run is still processing.');
+            return null;
+          }
+
+          setMetaViewState('missing');
+          if (options?.fallbackToIndividualOnMissing) {
+            setCommentViewMode('individual');
+            setStatusMessage('No meta directives found for this run yet. Showing individual reviewer comments.');
+          } else {
+            setStatusMessage('No meta directives available for this run yet. Recompute to synthesize now.');
+          }
+          return null;
         }
       }
+
       const created = await apiFetch<MetaReviewRunRead>('/meta-reviews', {
         method: 'POST',
         body: JSON.stringify({
@@ -731,15 +783,29 @@ function HomePageContent() {
         })
       });
       setMetaReviewRun(created);
-      setStatusMessage(
-        created.comments.length > 0
-          ? `Meta review ready (${created.comments.length} directives).`
-          : 'No meta directives produced for this version.'
-      );
+      if (isMetaSynthesisPendingStatus(created.status)) {
+        setMetaViewState('pending');
+        setStatusMessage('Meta synthesis queued. Directives will appear shortly.');
+      } else if (isMetaSynthesisFailedStatus(created.status)) {
+        setMetaViewState('error');
+        setStatusMessage(
+          created.error_message
+            ? `Meta synthesis failed: ${created.error_message}`
+            : 'Meta synthesis failed. Recompute to retry.'
+        );
+      } else {
+        setMetaViewState('ready');
+        setStatusMessage(
+          created.comments.length > 0
+            ? `Meta review ready (${created.comments.length} directives).`
+            : 'No meta directives produced for this version.'
+        );
+      }
       return created;
     } catch (error) {
       const message = normalizeError(error);
       setErrorMessage(message);
+      setMetaViewState('error');
       if (message.toLowerCase().includes('no reviewer comments available yet')) {
         setStatusMessage('Meta review is waiting for reviewer comments to arrive.');
       }
@@ -2746,14 +2812,20 @@ function HomePageContent() {
                   <button
                     className={`mode-button ${commentViewMode === 'individual' ? 'active' : ''}`}
                     type="button"
-                    onClick={() => setCommentViewMode('individual')}
+                    onClick={() => {
+                      setCommentModeSelectionSource('manual');
+                      setCommentViewMode('individual');
+                    }}
                   >
                     Individual
                   </button>
                   <button
                     className={`mode-button ${commentViewMode === 'meta' ? 'active' : ''}`}
                     type="button"
-                    onClick={() => setCommentViewMode('meta')}
+                    onClick={() => {
+                      setCommentModeSelectionSource('manual');
+                      setCommentViewMode('meta');
+                    }}
                   >
                     Meta
                   </button>
@@ -2911,15 +2983,28 @@ function HomePageContent() {
                 );
               })}
               {commentViewMode === 'meta' && isMetaLoading && (
-                <div className="empty-feed">Synthesizing meta comments…</div>
+                <div className="empty-feed">Loading meta directives…</div>
+              )}
+              {commentViewMode === 'meta' && !isMetaLoading && metaViewState === 'pending' && (
+                <div className="empty-feed">Meta directives are still being synthesized…</div>
+              )}
+              {commentViewMode === 'meta' && !isMetaLoading && metaViewState === 'missing' && (
+                <div className="empty-feed">
+                  No meta directives available for this run yet. Recompute to synthesize now.
+                </div>
+              )}
+              {commentViewMode === 'meta' && !isMetaLoading && metaViewState === 'error' && (
+                <div className="empty-feed">Unable to load meta directives right now.</div>
               )}
               {commentViewMode === 'meta' &&
                 !isMetaLoading &&
+                metaViewState === 'ready' &&
                 filteredMetaComments.length === 0 && (
                   <div className="empty-feed">No significant issues found.</div>
                 )}
               {commentViewMode === 'meta' &&
                 !isMetaLoading &&
+                metaViewState === 'ready' &&
                 filteredMetaComments.map((metaComment, index) => {
                   const topSource = metaComment.sources[0];
                   const pseudoColor = colorForPriority(metaComment.priority);
@@ -5000,6 +5085,24 @@ function colorForPriority(priority: 'critical' | 'high' | 'medium' | 'low' | str
   if (priority === 'high') return '#c57a1b';
   if (priority === 'medium') return '#2d6eea';
   return '#1d8a7a';
+}
+
+function isMetaSynthesisPendingStatus(status: string | null | undefined): boolean {
+  if (!status) return false;
+  const normalized = status.trim().toLowerCase();
+  return (
+    normalized === 'queued' ||
+    normalized === 'running' ||
+    normalized === 'pending' ||
+    normalized === 'in_progress' ||
+    normalized === 'processing'
+  );
+}
+
+function isMetaSynthesisFailedStatus(status: string | null | undefined): boolean {
+  if (!status) return false;
+  const normalized = status.trim().toLowerCase();
+  return normalized === 'failed' || normalized === 'error';
 }
 
 function buildCommentSignature(comments: CommentRead[]): string {

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -6,14 +6,29 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 
 let mockPathname = '/';
 let mockSearchParams = new URLSearchParams();
+let metaLatestScenario: 'missing' | 'available' | 'pending' | 'failed' = 'missing';
+
+function applyMockRoute(next: string) {
+  const parsed = new URL(next, 'http://localhost');
+  mockPathname = parsed.pathname;
+  mockSearchParams = new URLSearchParams(parsed.search);
+}
+
 const pushMock = vi.fn((next: string) => {
-  mockPathname = next;
+  applyMockRoute(next);
+});
+const replaceMock = vi.fn((next: string) => {
+  applyMockRoute(next);
 });
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
-  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
-  useSearchParams: () => ({ get: (key: string) => mockSearchParams.get(key) })
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParams.get(key),
+    has: (key: string) => mockSearchParams.has(key),
+    toString: () => mockSearchParams.toString()
+  })
 }));
 
 import HomePage from '../app/page';
@@ -29,7 +44,9 @@ describe('page controls', () => {
   beforeEach(() => {
     mockPathname = '/';
     mockSearchParams = new URLSearchParams();
+    metaLatestScenario = 'missing';
     pushMock.mockClear();
+    replaceMock.mockClear();
     const store = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -183,6 +200,107 @@ describe('page controls', () => {
             created_at: new Date().toISOString()
           }
         ]);
+      }
+      if (url.includes('/meta-reviews/latest?')) {
+        const targetsPrimaryVersion = url.includes('document_version_id=401');
+        if (targetsPrimaryVersion && metaLatestScenario === 'available') {
+          return json({
+            id: 901,
+            tenant_id: 'local-dev',
+            document_version_id: 401,
+            review_job_id: 501,
+            input_hash: 'meta-hash',
+            status: 'completed',
+            is_synthesized: true,
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            error_message: null,
+            created_at: new Date().toISOString(),
+            comments: [
+              {
+                id: 9501,
+                content: 'Clarify the opening section to reduce ambiguity.',
+                category: 'clarity',
+                priority: 'high',
+                impact: 'high',
+                effort: 'low',
+                confidence: 0.88,
+                why_now: 'Readers may misinterpret scope.',
+                recommended_change: 'Add a one-sentence framing statement.',
+                verification_step: 'Re-run clarity reviewer and confirm no repeat issue.',
+                status: 'open',
+                assignee: null,
+                due_at: null,
+                rank_score: 8.4,
+                start_offset: 0,
+                end_offset: 10,
+                order_index: 0,
+                is_unsynthesized: false,
+                sources: [
+                  {
+                    id: 9701,
+                    comment_id: 601,
+                    reviewer_name: 'Clarity Editor',
+                    reviewer_id: 1,
+                    original_comment_text: 'Clarify this section.'
+                  }
+                ]
+              }
+            ]
+          });
+        }
+        if (targetsPrimaryVersion && metaLatestScenario === 'pending') {
+          return json({
+            id: 902,
+            tenant_id: 'local-dev',
+            document_version_id: 401,
+            review_job_id: 501,
+            input_hash: 'meta-pending',
+            status: 'running',
+            is_synthesized: false,
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            error_message: null,
+            created_at: new Date().toISOString(),
+            comments: []
+          });
+        }
+        if (targetsPrimaryVersion && metaLatestScenario === 'failed') {
+          return json({
+            id: 904,
+            tenant_id: 'local-dev',
+            document_version_id: 401,
+            review_job_id: 501,
+            input_hash: 'meta-failed',
+            status: 'failed',
+            is_synthesized: false,
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            error_message: 'Provider timeout',
+            created_at: new Date().toISOString(),
+            comments: []
+          });
+        }
+        return json({ detail: 'Meta review run not found' }, 404);
+      }
+      if (url.endsWith('/meta-reviews') && init?.method === 'POST') {
+        return json(
+          {
+            id: 903,
+            tenant_id: 'local-dev',
+            document_version_id: 401,
+            review_job_id: 501,
+            input_hash: 'meta-created',
+            status: 'completed',
+            is_synthesized: true,
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            error_message: null,
+            created_at: new Date().toISOString(),
+            comments: []
+          },
+          201
+        );
       }
       if (url.endsWith('/personas') && (!init || init.method === 'GET')) return json(personasPayload);
       if (url.endsWith('/personas') && init?.method === 'POST') {
@@ -474,6 +592,68 @@ describe('page controls', () => {
     render(<HomePage />);
     const brand = await screen.findByRole('link', { name: /opinionated doc reviewer/i });
     expect(brand.getAttribute('href')).toBe('/library');
+  });
+
+  it('defaults to meta mode when latest meta directives are available', async () => {
+    metaLatestScenario = 'available';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Clarify the opening section to reduce ambiguity.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+  });
+
+  it('keeps meta mode and shows explicit error state when latest meta synthesis failed', async () => {
+    metaLatestScenario = 'failed';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Unable to load meta directives right now.')).toBeTruthy();
+    expect(await screen.findByText('Meta synthesis failed: Provider timeout')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+  });
+
+  it('shows explicit pending state while meta synthesis is still running', async () => {
+    metaLatestScenario = 'pending';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Meta directives are still being synthesized…')).toBeTruthy();
+    expect(await screen.findByText('Meta directives are still being synthesized.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+  });
+
+  it('falls back to individual mode when meta is missing, while preserving manual mode toggle', async () => {
+    metaLatestScenario = 'missing';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(
+      await screen.findByText('Anchored reviewer comments for this document version.')
+    ).toBeTruthy();
+    expect(
+      await screen.findByText('No meta directives found for this run yet. Showing individual reviewer comments.')
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(
+      (
+        await screen.findAllByText(
+          'No meta directives available for this run yet. Recompute to synthesize now.'
+        )
+      ).length
+    ).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
+    expect(await screen.findByRole('button', { name: 'Refresh' })).toBeTruthy();
   });
 
   it('refresh falls back to latest available comments when selected run is empty', async () => {


### PR DESCRIPTION
## Summary\n- default the comment panel to **Meta** mode when opening a document/version context\n- auto-fallback to **Individual** mode only when meta directives are missing and synthesis is not pending\n- add explicit meta lifecycle UX states for loading, pending, missing, error, and ready-empty\n- preserve manual mode toggles so users can switch bidirectionally after fallback\n- extend frontend coverage for meta-first default and explicit pending/missing/error behavior\n\n## Validation\n- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/zob/src/OpinionatedDocReviewer-fe-m1/frontend[39m

 [32m✓[39m tests/uploadFlow.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m tests/pageControls.test.tsx [2m([22m[2m13 tests[22m[2m)[22m[33m 1238[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m14 passed[39m[22m[90m (14)[39m
[2m   Start at [22m 19:02:46
[2m   Duration [22m 2.76s[2m (transform 571ms, setup 0ms, import 927ms, tests 1.27s, environment 477ms)[22m\n  - passed (2 files, 14 tests)\n- 
> opinionated-doc-reviewer-frontend@0.1.0 build /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend
> next build

   ▲ Next.js 15.5.12

   Creating an optimized production build ...
 ✓ Compiled successfully in 6.3s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/10) ...
   Generating static pages (2/10) 
   Generating static pages (4/10) 
   Generating static pages (7/10) 
 ✓ Generating static pages (10/10)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                      168 B         206 kB
├ ○ /_not-found                             1 kB         104 kB
├ ○ /admin                                 180 B         206 kB
├ ○ /agents                                180 B         206 kB
├ ○ /history                               180 B         206 kB
├ ○ /library                               180 B         206 kB
└ ○ /system                                180 B         206 kB
+ First Load JS shared by all             103 kB
  ├ chunks/1255-ad409e5887c155b0.js      45.7 kB
  ├ chunks/4bd1b696-100b9d70ed4e49c1.js  54.2 kB
  └ other shared chunks (total)          2.76 kB


ƒ Middleware                             34.3 kB

○  (Static)  prerendered as static content\n  - passed (Next.js production build succeeded)\n\nCloses #62\nCloses #63