### PR TITLE
feat(meta-api): add lightweight latest-status mode for bounded polling (#66)

### DIFF
--- a/backend/app/api/meta_reviews.py
+++ b/backend/app/api/meta_reviews.py
@@ -58,6 +58,30 @@ def _prepare_run_for_response(run: models.MetaReviewRun) -> models.MetaReviewRun
     return run
 
 
+def _build_run_metadata_payload(run: models.MetaReviewRun) -> dict:
+    normalize_meta_review_run_state(run)
+    return {
+        "id": run.id,
+        "tenant_id": run.tenant_id,
+        "document_version_id": run.document_version_id,
+        "review_job_id": run.review_job_id,
+        "input_hash": run.input_hash,
+        "status": run.status,
+        "queued_at": run.queued_at,
+        "running_at": run.running_at,
+        "completed_at": run.completed_at,
+        "failed_at": run.failed_at,
+        "is_synthesized": run.is_synthesized,
+        "provider": run.provider,
+        "model": run.model,
+        "error_code": run.error_code,
+        "error_message": run.error_message,
+        "error_details": run.error_details,
+        "created_at": run.created_at,
+        "comments": [],
+    }
+
+
 @router.post("", response_model=MetaReviewRunRead, status_code=201)
 def create_meta_review(
     payload: MetaReviewCreate,
@@ -128,19 +152,18 @@ def ensure_meta_review(
 def get_latest_meta_review(
     document_version_id: int = Query(gt=0),
     review_job_id: int | None = Query(default=None, gt=0),
+    include_comments: bool = Query(default=True),
     db: Session = Depends(get_db),
     tenant_id: str = Depends(get_tenant_id),
-) -> models.MetaReviewRun:
-    query = (
-        db.query(models.MetaReviewRun)
-        .options(
+) -> models.MetaReviewRun | dict:
+    query = db.query(models.MetaReviewRun).filter(
+        models.MetaReviewRun.tenant_id == tenant_id,
+        models.MetaReviewRun.document_version_id == document_version_id,
+    )
+    if include_comments:
+        query = query.options(
             selectinload(models.MetaReviewRun.comments).selectinload(models.MetaComment.sources)
         )
-        .filter(
-            models.MetaReviewRun.tenant_id == tenant_id,
-            models.MetaReviewRun.document_version_id == document_version_id,
-        )
-    )
     if review_job_id is not None:
         query = query.filter(models.MetaReviewRun.review_job_id == review_job_id).order_by(
             models.MetaReviewRun.created_at.desc(),
@@ -157,4 +180,6 @@ def get_latest_meta_review(
     run = query.first()
     if not run:
         raise HTTPException(status_code=404, detail="Meta review run not found")
-    return _prepare_run_for_response(run)
+    if include_comments:
+        return _prepare_run_for_response(run)
+    return _build_run_metadata_payload(run)

--- a/backend/tests/test_meta_reviews.py
+++ b/backend/tests/test_meta_reviews.py
@@ -181,6 +181,64 @@ def test_meta_review_create_and_cache(client, monkeypatch) -> None:
     assert latest_resp.json()["id"] == body["id"]
 
 
+def test_latest_meta_review_supports_lightweight_mode_without_comments(client, monkeypatch) -> None:
+    headers = {"X-Tenant-Id": "tenant-meta-latest-lightweight"}
+    version, job = _seed_review_data(client, headers, monkeypatch)
+
+    monkeypatch.setattr(
+        "app.reviews.meta_reviewer.generate_completion",
+        lambda _: json.dumps(
+            [
+                {
+                    "content": "Clarify auth flow and explicit token lifecycle.",
+                    "category": "security",
+                    "priority": "high",
+                    "impact": "high",
+                    "effort": "low",
+                    "confidence": 0.88,
+                    "why_now": "Current wording could cause insecure implementations.",
+                    "recommended_change": "Define validation and token expiry behavior.",
+                    "verification_step": "Confirm security review comments converge to one directive.",
+                    "status": "open",
+                    "assignee": None,
+                    "due_at": None,
+                    "contributing_reviewers": ["A", "B"],
+                    "location": {"start_offset": 0, "end_offset": 28},
+                }
+            ]
+        ),
+    )
+
+    created_resp = client.post(
+        "/api/meta-reviews",
+        json={"document_version_id": version["id"], "review_job_id": job["id"], "force": True},
+        headers=headers,
+    )
+    assert created_resp.status_code == 201
+
+    full_latest_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}&review_job_id={job['id']}",
+        headers=headers,
+    )
+    assert full_latest_resp.status_code == 200
+    full_latest = full_latest_resp.json()
+    assert len(full_latest["comments"]) >= 1
+
+    lightweight_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}&review_job_id={job['id']}&include_comments=false",
+        headers=headers,
+    )
+    assert lightweight_resp.status_code == 200
+    lightweight = lightweight_resp.json()
+    assert lightweight["id"] == full_latest["id"]
+    assert lightweight["status"] == full_latest["status"]
+    assert lightweight["queued_at"] == full_latest["queued_at"]
+    assert lightweight["running_at"] == full_latest["running_at"]
+    assert lightweight["completed_at"] == full_latest["completed_at"]
+    assert lightweight["failed_at"] == full_latest["failed_at"]
+    assert lightweight["comments"] == []
+
+
 def test_latest_meta_review_prefers_newest_review_context_over_stale_created_later(
     client,
     monkeypatch,
@@ -260,6 +318,16 @@ def test_latest_meta_review_prefers_newest_review_context_over_stale_created_lat
     latest = latest_resp.json()
     assert latest["review_job_id"] == newer_job["id"]
     assert latest["id"] == newer_run["id"]
+
+    lightweight_resp = client.get(
+        f"/api/meta-reviews/latest?document_version_id={version['id']}&include_comments=false",
+        headers=headers,
+    )
+    assert lightweight_resp.status_code == 200
+    lightweight = lightweight_resp.json()
+    assert lightweight["review_job_id"] == newer_job["id"]
+    assert lightweight["id"] == newer_run["id"]
+    assert lightweight["comments"] == []
 
 
 def test_latest_meta_review_prefers_review_context_over_newer_unscoped_run(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add optional include_comments query flag to GET /api/meta-reviews/latest (default true)
- support lightweight polling mode with include_comments=false that returns full run metadata (status/lifecycle/error fields) with comments=[]
- keep existing latest-selection logic unchanged (including stale-run guard behavior)
- add focused regression tests for lightweight mode and default no-regression behavior

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_meta_reviews.py tests/test_review_queue.py tests/test_review_worker.py tests/test_comments_and_reviews.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/api/meta_reviews.py app/schemas/meta_review.py tests/test_meta_reviews.py

Refs #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meta-review retrieval now supports a lightweight mode to fetch data without comments, improving performance when comment details are unnecessary.

* **Tests**
  * Added test coverage for lightweight meta-review retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->