### PR TITLE
feat(frontend): add directive drill-down to source comments (#64)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -708,10 +708,25 @@ main {
   padding: 8px;
 }
 
+.meta-source-item.selected {
+  border-color: rgba(45, 110, 234, 0.42);
+  box-shadow: 0 0 0 1px rgba(45, 110, 234, 0.25);
+}
+
 .meta-source-head {
   font-weight: 700;
   margin-bottom: 4px;
   color: var(--ink-700);
+}
+
+.meta-source-excerpt {
+  margin-top: 6px;
+  color: var(--ink-500);
+  font-size: 12px;
+}
+
+.source-jump-button {
+  margin-top: 8px;
 }
 
 .empty-feed {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -44,6 +44,7 @@ import {
   DocumentVersionRead,
   PersonaRead,
   ReviewJobRead,
+  MetaCommentSourceRead,
   MetaReviewRunRead,
   WorkerMonitorRead,
   SystemConfigRead,
@@ -373,8 +374,8 @@ function HomePageContent() {
     if (!focusedCommentId) return;
     const card = cardRefs.current[focusedCommentId];
     const mark = markRefs.current[focusedCommentId];
-    card?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
-    mark?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+    card?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+    mark?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
   }, [focusedCommentId]);
 
   useEffect(() => {
@@ -385,8 +386,8 @@ function HomePageContent() {
     hoverAlignFrameRef.current = requestAnimationFrame(() => {
       const mark = markRefs.current[hoveredCommentId];
       const card = cardRefs.current[hoveredCommentId];
-      card?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
-      mark?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      card?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      mark?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
     });
     return () => {
       if (hoverAlignFrameRef.current !== null) {
@@ -1559,6 +1560,13 @@ function HomePageContent() {
       ),
     [visibleComments]
   );
+  const commentById = useMemo(() => {
+    const map = new Map<number, CommentRead>();
+    for (const comment of comments) {
+      map.set(comment.id, comment);
+    }
+    return map;
+  }, [comments]);
   const hasFilteredOutComments = comments.length > 0 && visibleComments.length === 0;
 
   const personaMap = useMemo(() => {
@@ -1645,12 +1653,12 @@ function HomePageContent() {
     }
     hoverAlignFrameRef.current = requestAnimationFrame(() => {
       const card = metaCardRefs.current[hoveredMetaCommentId];
-      card?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      card?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
       const metaItem = filteredMetaComments.find((item) => item.id === hoveredMetaCommentId);
       const sourceCommentId = metaItem?.sources[0]?.comment_id ?? null;
       if (sourceCommentId) {
         const mark = markRefs.current[sourceCommentId];
-        mark?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+        mark?.scrollIntoView?.({ behavior: 'smooth', block: 'center', inline: 'nearest' });
       }
     });
     return () => {
@@ -2115,6 +2123,30 @@ function HomePageContent() {
   function focusComment(commentId: number) {
     setFocusedCommentId((prev) => (prev === commentId ? null : commentId));
     setDocMode('source');
+  }
+
+  function drillDownToSourceComment(source: MetaCommentSourceRead) {
+    const sourceComment = commentById.get(source.comment_id);
+    if (!sourceComment) {
+      setStatusMessage(`Source comment #${source.comment_id} is unavailable for this run.`);
+      return;
+    }
+
+    if (!enabledPersonas.has(sourceComment.persona_id)) {
+      setEnabledPersonas((prev) => {
+        const next = new Set(prev);
+        next.add(sourceComment.persona_id);
+        return next;
+      });
+    }
+
+    setCommentModeSelectionSource('manual');
+    setCommentViewMode('individual');
+    setFocusedMetaCommentId(null);
+    setHoveredMetaCommentId(null);
+    setFocusedCommentId(sourceComment.id);
+    setDocMode('source');
+    setStatusMessage(`Jumped to source comment #${source.comment_id} (${source.reviewer_name}).`);
   }
 
   function handleFeedPointerMove(event: ReactMouseEvent<HTMLDivElement>) {
@@ -3196,14 +3228,36 @@ function HomePageContent() {
                       <details className="comment-source">
                         <summary>Show sources ({metaComment.sources.length})</summary>
                         <div className="meta-sources">
-                          {metaComment.sources.map((source) => (
-                            <div key={source.id} className="meta-source-item">
-                              <div className="meta-source-head">
-                                {source.reviewer_name} · #{source.comment_id}
+                          {metaComment.sources.map((source) => {
+                            const sourceComment = commentById.get(source.comment_id);
+                            const sourceExcerpt = sourceComment?.excerpt?.trim();
+                            const isSelectedSource = activeCommentId === source.comment_id;
+                            return (
+                              <div
+                                key={source.id}
+                                className={`meta-source-item ${isSelectedSource ? 'selected' : ''}`}
+                              >
+                                <div className="meta-source-head">
+                                  {source.reviewer_name} · #{source.comment_id}
+                                </div>
+                                <div>{source.original_comment_text}</div>
+                                {sourceExcerpt && (
+                                  <div className="meta-source-excerpt">Anchor excerpt: “{sourceExcerpt}”</div>
+                                )}
+                                <button
+                                  type="button"
+                                  className="ghost-button source-jump-button"
+                                  onClick={(event) => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    drillDownToSourceComment(source);
+                                  }}
+                                >
+                                  Jump to source #{source.comment_id}
+                                </button>
                               </div>
-                              <div>{source.original_comment_text}</div>
-                            </div>
-                          ))}
+                            );
+                          })}
                         </div>
                       </details>
                     </div>

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -766,6 +766,50 @@ describe('page controls', () => {
     });
   });
 
+  it('drills down from a meta directive source into the linked reviewer comment', async () => {
+    metaLatestScenario = 'available';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101&mode=meta&directive=9501');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    fireEvent.click((await screen.findAllByText('Show sources (1)'))[0]);
+    expect(await screen.findByText('Anchor excerpt: “Design”')).toBeTruthy();
+
+    replaceMock.mockClear();
+    fireEvent.click(await screen.findByRole('button', { name: 'Jump to source #601' }));
+
+    expect(
+      await screen.findByText('Anchored reviewer comments for this document version.')
+    ).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'Refresh' })).toBeTruthy();
+    await waitFor(() => {
+      expect(document.querySelector('.comment-card[data-comment-id="601"].selected')).toBeTruthy();
+    });
+    await waitFor(() => {
+      const urls = replaceMock.mock.calls.map((call) => String(call[0]));
+      expect(urls.some((url) => url.includes('mode=individual') && !url.includes('directive='))).toBe(true);
+    });
+  });
+
+  it('supports drill-down roundtrip back to meta mode without breaking meta-first flow', async () => {
+    metaLatestScenario = 'available';
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+
+    fireEvent.click((await screen.findAllByText('Show sources (1)'))[0]);
+    fireEvent.click(await screen.findByRole('button', { name: 'Jump to source #601' }));
+    expect(await screen.findByRole('button', { name: 'Refresh' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
+    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Clarify the opening section to reduce ambiguity.')).toBeTruthy();
+  });
+
   it('refresh falls back to latest available comments when selected run is empty', async () => {
     mockPathname = '/';
     mockSearchParams = new URLSearchParams('doc=101');


### PR DESCRIPTION
## Summary
- add directive source drill-down controls in meta cards so each source can jump directly to its linked reviewer comment
- include source anchor excerpt in the directive source list for clearer evidence traceability
- switch to individual mode on source jump, focus the linked comment, and keep URL mode/directive state synchronized
- harden source-navigation scroll behavior with optional `scrollIntoView` guards for deterministic browser/test execution
- add regression coverage for directive source drill-down and meta-first roundtrip stability

## Validation
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && NODE_ENV=test pnpm vitest run tests/pageControls.test.tsx tests/uploadFlow.test.ts`
  - passed (2 files, 19 tests)
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && pnpm run build`
  - passed (Next.js production build succeeded)

Closes #64
