### PR TITLE
feat(frontend): add bounded meta-synthesis polling flow (#66)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -52,6 +52,7 @@ import {
 } from '../src/lib/types';
 
 const POLL_INTERVAL_MS = 1200;
+const META_STATUS_POLL_MAX_ATTEMPTS = 8;
 const AGENT_COLORS = ['#1d8a7a', '#2d6eea', '#b7482f', '#7a4bd3', '#c57a1b', '#0f6e88'];
 
 type DocSegment = { text: string; comment?: CommentRead };
@@ -189,6 +190,7 @@ function HomePageContent() {
   const [metaReviewRun, setMetaReviewRun] = useState<MetaReviewRunRead | null>(null);
   const [metaViewState, setMetaViewState] = useState<MetaViewState>('idle');
   const [isMetaLoading, setIsMetaLoading] = useState(false);
+  const [isPageVisible, setIsPageVisible] = useState(true);
   const [metaCategoryFilter, setMetaCategoryFilter] = useState<
     'all' | 'structure' | 'clarity' | 'technical' | 'security' | 'accessibility' | 'style'
   >('all');
@@ -371,6 +373,123 @@ function HomePageContent() {
   ]);
 
   useEffect(() => {
+    if (normalizedPath !== '/') return;
+    if (commentViewMode !== 'meta') return;
+    if (!selectedVersionId) return;
+    if (metaViewState !== 'pending') return;
+    if (!isPageVisible) return;
+
+    let cancelled = false;
+    let attempts = 0;
+    let timeout: number | null = null;
+
+    const clearTimer = () => {
+      if (timeout !== null) {
+        window.clearTimeout(timeout);
+        timeout = null;
+      }
+    };
+
+    const scheduleNextPoll = () => {
+      if (cancelled) return;
+      if (attempts >= META_STATUS_POLL_MAX_ATTEMPTS) {
+        setStatusMessage(
+          'Meta directives are still being synthesized. Auto-refresh paused to avoid noisy polling.'
+        );
+        return;
+      }
+      timeout = window.setTimeout(() => {
+        void pollMetaStatus();
+      }, metaStatusPollDelayForAttempt(attempts + 1));
+    };
+
+    const pollMetaStatus = async () => {
+      clearTimer();
+      if (cancelled) return;
+      attempts += 1;
+      try {
+        const statusOnly = await fetchLatestMetaReviewRun(selectedVersionId, selectedReviewJobId, {
+          includeComments: false
+        });
+        if (cancelled) return;
+
+        setMetaReviewRun((previous) => {
+          if (
+            statusOnly.comments.length === 0 &&
+            previous &&
+            previous.id === statusOnly.id &&
+            previous.comments.length > 0
+          ) {
+            return { ...statusOnly, comments: previous.comments };
+          }
+          return statusOnly;
+        });
+
+        if (isMetaSynthesisPendingStatus(statusOnly.status)) {
+          scheduleNextPoll();
+          return;
+        }
+
+        if (isMetaSynthesisFailedStatus(statusOnly.status)) {
+          setMetaViewState('error');
+          setStatusMessage(
+            statusOnly.error_message
+              ? `Meta synthesis failed: ${statusOnly.error_message}`
+              : 'Meta synthesis failed. Recompute to retry.'
+          );
+          return;
+        }
+
+        const hydrated = await fetchLatestMetaReviewRun(selectedVersionId, selectedReviewJobId, {
+          includeComments: true
+        });
+        if (cancelled) return;
+
+        setMetaReviewRun(hydrated);
+        if (isMetaSynthesisPendingStatus(hydrated.status)) {
+          setMetaViewState('pending');
+          setStatusMessage('Meta directives are still being synthesized.');
+          scheduleNextPoll();
+          return;
+        }
+
+        if (isMetaSynthesisFailedStatus(hydrated.status)) {
+          setMetaViewState('error');
+          setStatusMessage(
+            hydrated.error_message
+              ? `Meta synthesis failed: ${hydrated.error_message}`
+              : 'Meta synthesis failed. Recompute to retry.'
+          );
+          return;
+        }
+
+        setMetaViewState('ready');
+        setStatusMessage(
+          hydrated.comments.length > 0
+            ? `Meta review loaded (${hydrated.comments.length} directives).`
+            : 'Meta review loaded (no directives).'
+        );
+      } catch {
+        if (cancelled) return;
+        scheduleNextPoll();
+      }
+    };
+
+    scheduleNextPoll();
+    return () => {
+      cancelled = true;
+      clearTimer();
+    };
+  }, [
+    normalizedPath,
+    commentViewMode,
+    selectedVersionId,
+    selectedReviewJobId,
+    metaViewState,
+    isPageVisible
+  ]);
+
+  useEffect(() => {
     if (!focusedCommentId) return;
     const card = cardRefs.current[focusedCommentId];
     const mark = markRefs.current[focusedCommentId];
@@ -451,6 +570,18 @@ function HomePageContent() {
     }, 4500);
     return () => window.clearTimeout(timer);
   }, [statusMessage]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const syncVisibility = () => {
+      setIsPageVisible(document.visibilityState !== 'hidden');
+    };
+    syncVisibility();
+    document.addEventListener('visibilitychange', syncVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', syncVisibility);
+    };
+  }, []);
 
   useEffect(() => {
     const previous = document.body.style.overflow;
@@ -721,6 +852,23 @@ function HomePageContent() {
     }
   }
 
+  async function fetchLatestMetaReviewRun(
+    versionId: number,
+    reviewJobId?: number | null,
+    options?: {
+      includeComments?: boolean;
+    }
+  ): Promise<MetaReviewRunRead> {
+    const params = new URLSearchParams({ document_version_id: String(versionId) });
+    if (reviewJobId) {
+      params.set('review_job_id', String(reviewJobId));
+    }
+    if (options?.includeComments === false) {
+      params.set('include_comments', 'false');
+    }
+    return apiFetch<MetaReviewRunRead>(`/meta-reviews/latest?${params.toString()}`);
+  }
+
   async function loadOrCreateMetaReview(
     versionId: number,
     reviewJobId?: number | null,
@@ -734,11 +882,10 @@ function HomePageContent() {
     setMetaViewState('loading');
     try {
       if (!force) {
-        const query = reviewJobId
-          ? `/meta-reviews/latest?document_version_id=${versionId}&review_job_id=${reviewJobId}`
-          : `/meta-reviews/latest?document_version_id=${versionId}`;
         try {
-          const latest = await apiFetch<MetaReviewRunRead>(query);
+          const latest = await fetchLatestMetaReviewRun(versionId, reviewJobId, {
+            includeComments: true
+          });
           setMetaReviewRun(latest);
           if (isMetaSynthesisPendingStatus(latest.status)) {
             setMetaViewState('pending');
@@ -5261,6 +5408,11 @@ function isMetaSynthesisFailedStatus(status: string | null | undefined): boolean
   if (!status) return false;
   const normalized = status.trim().toLowerCase();
   return normalized === 'failed' || normalized === 'error';
+}
+
+function metaStatusPollDelayForAttempt(attempt: number): number {
+  const normalizedAttempt = Math.max(1, attempt);
+  return Math.min(40 * 2 ** (normalizedAttempt - 1), 320);
 }
 
 function parseCommentViewModeParam(value: string | null): 'individual' | 'meta' | null {

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -7,6 +7,9 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 let mockPathname = '/';
 let mockSearchParams = new URLSearchParams();
 let metaLatestScenario: 'missing' | 'available' | 'pending' | 'failed' = 'missing';
+let metaStatusPollSequence: Array<'running' | 'completed' | 'failed' | 'not_found'> = [];
+let metaStatusPollRequestCount = 0;
+let metaStatusReachedCompletion = false;
 
 function applyMockRoute(next: string) {
   const parsed = new URL(next, 'http://localhost');
@@ -45,6 +48,9 @@ describe('page controls', () => {
     mockPathname = '/';
     mockSearchParams = new URLSearchParams();
     metaLatestScenario = 'missing';
+    metaStatusPollSequence = [];
+    metaStatusPollRequestCount = 0;
+    metaStatusReachedCompletion = false;
     pushMock.mockClear();
     replaceMock.mockClear();
     const store = new Map<string, string>();
@@ -202,9 +208,11 @@ describe('page controls', () => {
         ]);
       }
       if (url.includes('/meta-reviews/latest?')) {
-        const targetsPrimaryVersion = url.includes('document_version_id=401');
-        if (targetsPrimaryVersion && metaLatestScenario === 'available') {
-          return json({
+        const parsed = new URL(url, 'http://localhost');
+        const targetsPrimaryVersion = parsed.searchParams.get('document_version_id') === '401';
+        const includeComments = parsed.searchParams.get('include_comments') !== 'false';
+        const asAvailable = () =>
+          json({
             id: 901,
             tenant_id: 'local-dev',
             document_version_id: 401,
@@ -248,9 +256,8 @@ describe('page controls', () => {
               }
             ]
           });
-        }
-        if (targetsPrimaryVersion && metaLatestScenario === 'pending') {
-          return json({
+        const asPending = () =>
+          json({
             id: 902,
             tenant_id: 'local-dev',
             document_version_id: 401,
@@ -264,9 +271,8 @@ describe('page controls', () => {
             created_at: new Date().toISOString(),
             comments: []
           });
-        }
-        if (targetsPrimaryVersion && metaLatestScenario === 'failed') {
-          return json({
+        const asFailed = () =>
+          json({
             id: 904,
             tenant_id: 'local-dev',
             document_version_id: 401,
@@ -280,7 +286,50 @@ describe('page controls', () => {
             created_at: new Date().toISOString(),
             comments: []
           });
+
+        if (!targetsPrimaryVersion) {
+          return json({ detail: 'Meta review run not found' }, 404);
         }
+
+        if (!includeComments) {
+          metaStatusPollRequestCount += 1;
+          const nextPollState = metaStatusPollSequence.shift() ?? null;
+          if (nextPollState === 'running') {
+            return asPending();
+          }
+          if (nextPollState === 'completed') {
+            metaStatusReachedCompletion = true;
+            return json({
+              id: 901,
+              tenant_id: 'local-dev',
+              document_version_id: 401,
+              review_job_id: 501,
+              input_hash: 'meta-hash',
+              status: 'completed',
+              is_synthesized: true,
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+              error_message: null,
+              created_at: new Date().toISOString(),
+              comments: []
+            });
+          }
+          if (nextPollState === 'failed') {
+            return asFailed();
+          }
+          if (nextPollState === 'not_found') {
+            return json({ detail: 'Meta review run not found' }, 404);
+          }
+
+          if (metaStatusReachedCompletion || metaLatestScenario === 'available') return asAvailable();
+          if (metaLatestScenario === 'pending') return asPending();
+          if (metaLatestScenario === 'failed') return asFailed();
+          return json({ detail: 'Meta review run not found' }, 404);
+        }
+
+        if (metaStatusReachedCompletion || metaLatestScenario === 'available') return asAvailable();
+        if (metaLatestScenario === 'pending') return asPending();
+        if (metaLatestScenario === 'failed') return asFailed();
         return json({ detail: 'Meta review run not found' }, 404);
       }
       if (url.endsWith('/meta-reviews') && init?.method === 'POST') {
@@ -627,6 +676,53 @@ describe('page controls', () => {
     expect(await screen.findByText('Meta directives are still being synthesized…')).toBeTruthy();
     expect(await screen.findByText('Meta directives are still being synthesized.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
+  });
+
+  it('polls lightweight meta status while pending and hydrates full directives on completion', async () => {
+    metaLatestScenario = 'pending';
+    metaStatusPollSequence = ['running', 'completed'];
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    expect(await screen.findByText('Meta directives are still being synthesized.')).toBeTruthy();
+    expect(await screen.findByText('Meta review loaded (1 directives).')).toBeTruthy();
+    expect(await screen.findByText('Clarify the opening section to reduce ambiguity.')).toBeTruthy();
+
+    const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((args) =>
+      String(args[0])
+    );
+    const statusPollCalls = calls.filter(
+      (url) => url.includes('/meta-reviews/latest?') && url.includes('include_comments=false')
+    );
+    expect(statusPollCalls.length).toBeGreaterThan(0);
+    expect(statusPollCalls.some((url) => url.includes('review_job_id=501'))).toBe(true);
+
+    const hydratedCalls = calls.filter(
+      (url) => url.includes('/meta-reviews/latest?') && !url.includes('include_comments=false')
+    );
+    expect(hydratedCalls.length).toBeGreaterThan(1);
+  });
+
+  it('bounds pending meta polling and pauses auto-refresh after max attempts', async () => {
+    metaLatestScenario = 'pending';
+    metaStatusPollSequence = Array.from({ length: 16 }, () => 'running');
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    render(<HomePage />);
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(
+            'Meta directives are still being synthesized. Auto-refresh paused to avoid noisy polling.'
+          )
+        ).toBeTruthy();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(metaStatusPollRequestCount).toBe(8);
   });
 
   it('recompute retries meta synthesis from failed state and keeps meta mode active', async () => {


### PR DESCRIPTION
## Summary
- add bounded frontend polling for meta synthesis while in meta mode and pending state
- use lightweight status checks (`GET /meta-reviews/latest?...&include_comments=false`) during polling to reduce payload
- hydrate full directives (`include_comments=true`) only after a terminal success status is observed
- stop polling deterministically when hidden/inactive context changes or max attempts are reached
- preserve explicit UX transitions for pending, failed, and completed synthesis states without URL churn
- extend page-controls tests to cover lightweight polling completion handoff and bounded backoff stop behavior

## Validation
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && NODE_ENV=test pnpm vitest run tests/pageControls.test.tsx tests/uploadFlow.test.ts`
  - passed (2 files, 23 tests)
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && pnpm run build`
  - passed (Next.js production build succeeded)

Closes #66
