### PR TITLE
feat(review-engine): unify persona contract payload across review paths (#75)

### DIFF
--- a/backend/app/reviews/prompt_builder.py
+++ b/backend/app/reviews/prompt_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 from app.db import models
@@ -21,19 +22,33 @@ REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS = (
 def _normalize_focus_areas(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
-    return [str(item) for item in value]
+    normalized: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            normalized.append(text)
+    return normalized
 
 
 def _normalize_examples(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
-    return [str(item) for item in value]
+    normalized: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            normalized.append(text)
+    return normalized
 
 
 def _normalize_output_requirements(value: Any) -> dict:
     if not isinstance(value, dict):
         return {}
-    return dict(value)
+    return copy.deepcopy(value)
 
 
 def build_persona_execution_spec(persona: models.Persona) -> dict[str, Any]:

--- a/backend/app/reviews/prompt_builder.py
+++ b/backend/app/reviews/prompt_builder.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.db import models
+
+REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "system_prompt",
+    "focus_areas",
+    "tone",
+    "reference_notes",
+    "output_requirements",
+    "examples",
+    "sort_order",
+)
+
+
+def _normalize_focus_areas(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _normalize_examples(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _normalize_output_requirements(value: Any) -> dict:
+    if not isinstance(value, dict):
+        return {}
+    return dict(value)
+
+
+def build_persona_execution_spec(persona: models.Persona) -> dict[str, Any]:
+    return {
+        "id": persona.id,
+        "name": persona.name,
+        "description": persona.description,
+        "system_prompt": persona.system_prompt,
+        "focus_areas": _normalize_focus_areas(persona.focus_areas),
+        "tone": persona.tone,
+        "reference_notes": persona.reference_notes,
+        "output_requirements": _normalize_output_requirements(persona.output_requirements),
+        "examples": _normalize_examples(persona.examples),
+        "sort_order": persona.sort_order,
+    }
+
+
+def build_persona_execution_specs(personas: list[models.Persona]) -> list[dict[str, Any]]:
+    return [build_persona_execution_spec(persona) for persona in personas]

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -11,6 +11,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout, as_completed
 from app.reviews.meta_reviewer import ensure_meta_review_run
 from app.reviews.parsing import parse_review_output, persist_comment_payloads, normalize_output_requirements, ParsedComment
+from app.reviews.prompt_builder import build_persona_execution_spec, build_persona_execution_specs
 from app.reviews.git_repo import ensure_repo
 from app.reviews.review_storage import write_review_and_commit
 from datetime import datetime, timezone
@@ -119,20 +120,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                 .all()
             )
 
-        persona_specs = [
-            {
-                "id": persona.id,
-                "name": persona.name,
-                "description": persona.description,
-                "system_prompt": persona.system_prompt,
-                "focus_areas": persona.focus_areas,
-                "tone": persona.tone,
-                "reference_notes": persona.reference_notes,
-                "output_requirements": persona.output_requirements,
-                "examples": persona.examples,
-            }
-            for persona in personas
-        ]
+        persona_specs = build_persona_execution_specs(personas)
 
         results: list[dict] = []
         max_workers = max(1, min(len(persona_specs), 6))
@@ -248,20 +236,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
 
 
 def generate_comments(persona: models.Persona, content: str) -> list[ParsedComment]:
-    return generate_comments_for_spec(
-        {
-            "id": persona.id,
-            "name": persona.name,
-            "description": persona.description,
-            "system_prompt": persona.system_prompt,
-            "focus_areas": persona.focus_areas,
-            "tone": persona.tone,
-            "reference_notes": persona.reference_notes,
-            "output_requirements": persona.output_requirements,
-            "examples": persona.examples,
-        },
-        content,
-    )
+    return generate_comments_for_spec(build_persona_execution_spec(persona), content)
 
 
 def generate_comments_for_spec(persona: dict, content: str) -> list[ParsedComment]:
@@ -528,14 +503,7 @@ def retry_failed_persona_in_job(
         db.commit()
 
         comments = generate_comments_for_spec(
-            {
-                "id": persona.id,
-                "name": persona.name,
-                "description": persona.description,
-                "system_prompt": persona.system_prompt,
-                "focus_areas": persona.focus_areas,
-                "tone": persona.tone,
-            },
+            build_persona_execution_spec(persona),
             version.content,
         )
         persist_comments(

--- a/backend/tests/test_review_prompt.py
+++ b/backend/tests/test_review_prompt.py
@@ -1,3 +1,8 @@
+from app.db import models
+from app.reviews.prompt_builder import (
+    REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS,
+    build_persona_execution_spec,
+)
 from app.reviews.worker import build_prompt
 
 
@@ -11,3 +16,57 @@ def test_build_prompt_handles_none_focus_items() -> None:
         content="Sample content",
     )
     assert "Focus areas: security, compliance" in prompt
+
+
+def test_build_persona_execution_spec_includes_all_required_contract_fields() -> None:
+    persona = models.Persona(
+        tenant_id="tenant-prompt-spec",
+        name="Contract Persona",
+        description="checks contract fields",
+        system_prompt="Review contract consistency.",
+        focus_areas=["clarity", "risk"],
+        tone="direct",
+        reference_notes="Always include evidence.",
+        output_requirements={"format": "bullet_list", "max_bullets": 3},
+        examples=["- \"quote\" :: clarify wording"],
+        sort_order=42,
+        is_active=True,
+        is_default=False,
+        is_system_locked=False,
+    )
+
+    spec = build_persona_execution_spec(persona)
+
+    assert set(REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS).issubset(spec.keys())
+    assert spec["name"] == persona.name
+    assert spec["reference_notes"] == persona.reference_notes
+    assert spec["output_requirements"] == persona.output_requirements
+    assert spec["examples"] == persona.examples
+    assert spec["sort_order"] == 42
+
+
+def test_build_persona_execution_spec_returns_copies_for_mutable_fields() -> None:
+    persona = models.Persona(
+        tenant_id="tenant-prompt-spec-copy",
+        name="Copy Persona",
+        description="copy check",
+        system_prompt="Review contract consistency.",
+        focus_areas=["clarity"],
+        tone="direct",
+        reference_notes="notes",
+        output_requirements={"format": "bullet_list"},
+        examples=["example"],
+        sort_order=7,
+        is_active=True,
+        is_default=False,
+        is_system_locked=False,
+    )
+
+    spec = build_persona_execution_spec(persona)
+    spec["focus_areas"].append("mutated")
+    spec["output_requirements"]["max_bullets"] = 99
+    spec["examples"].append("mutated")
+
+    assert persona.focus_areas == ["clarity"]
+    assert persona.output_requirements == {"format": "bullet_list"}
+    assert persona.examples == ["example"]

--- a/backend/tests/test_review_prompt.py
+++ b/backend/tests/test_review_prompt.py
@@ -54,7 +54,7 @@ def test_build_persona_execution_spec_returns_copies_for_mutable_fields() -> Non
         focus_areas=["clarity"],
         tone="direct",
         reference_notes="notes",
-        output_requirements={"format": "bullet_list"},
+        output_requirements={"format": "bullet_list", "limits": {"max_bullets": 3}},
         examples=["example"],
         sort_order=7,
         is_active=True,
@@ -65,8 +65,35 @@ def test_build_persona_execution_spec_returns_copies_for_mutable_fields() -> Non
     spec = build_persona_execution_spec(persona)
     spec["focus_areas"].append("mutated")
     spec["output_requirements"]["max_bullets"] = 99
+    spec["output_requirements"]["limits"]["max_bullets"] = 99
     spec["examples"].append("mutated")
 
     assert persona.focus_areas == ["clarity"]
-    assert persona.output_requirements == {"format": "bullet_list"}
+    assert persona.output_requirements == {
+        "format": "bullet_list",
+        "limits": {"max_bullets": 3},
+    }
     assert persona.examples == ["example"]
+
+
+def test_build_persona_execution_spec_filters_blank_focus_areas_and_examples() -> None:
+    persona = models.Persona(
+        tenant_id="tenant-prompt-spec-normalize",
+        name="Normalize Persona",
+        description="normalize check",
+        system_prompt="Review contract consistency.",
+        focus_areas=[None, " clarity ", "", "   ", 123],
+        tone="direct",
+        reference_notes="notes",
+        output_requirements={"format": "bullet_list"},
+        examples=[None, " example ", "", "   ", 7],
+        sort_order=9,
+        is_active=True,
+        is_default=False,
+        is_system_locked=False,
+    )
+
+    spec = build_persona_execution_spec(persona)
+
+    assert spec["focus_areas"] == ["clarity", "123"]
+    assert spec["examples"] == ["example", "7"]

--- a/backend/tests/test_review_worker.py
+++ b/backend/tests/test_review_worker.py
@@ -5,9 +5,12 @@ from types import SimpleNamespace
 from app.db import models
 from app.db.init_db import seed_default_personas
 from app.db.session import SessionLocal
+from app.reviews.parsing import ParsedComment
+from app.reviews.prompt_builder import REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS
 from app.reviews.worker import (
     _auto_trigger_meta_synthesis,
     _generate_with_timeout_retry,
+    retry_failed_persona_in_job,
     run_review_job,
 )
 
@@ -40,6 +43,129 @@ def _seed_review_context(db, tenant_id: str) -> tuple[models.DocumentVersion, mo
     db.refresh(job)
 
     return version, job
+
+
+def _assert_full_persona_contract(spec: dict) -> None:
+    assert set(REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS).issubset(spec.keys())
+    assert spec["id"] is not None
+    assert isinstance(spec["name"], str)
+    assert isinstance(spec["focus_areas"], list)
+    assert isinstance(spec["output_requirements"], dict)
+    assert isinstance(spec["examples"], list)
+
+
+def test_run_review_job_uses_full_persona_contract_payload(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-persona-contract-run"
+        monkeypatch.setattr("app.reviews.worker.settings.DOC_REPO_ENABLED", False)
+        monkeypatch.setattr("app.reviews.worker.settings.META_AUTO_SYNTHESIS_ENABLED", False)
+
+        version, job = _seed_review_context(db, tenant_id)
+
+        captured_specs: list[dict] = []
+
+        def _capture_generate_comments_for_spec(persona, _content):
+            captured_specs.append(
+                {
+                    "id": persona.get("id"),
+                    "name": persona.get("name"),
+                    "description": persona.get("description"),
+                    "system_prompt": persona.get("system_prompt"),
+                    "focus_areas": list(persona.get("focus_areas") or []),
+                    "tone": persona.get("tone"),
+                    "reference_notes": persona.get("reference_notes"),
+                    "output_requirements": dict(persona.get("output_requirements") or {}),
+                    "examples": list(persona.get("examples") or []),
+                    "sort_order": persona.get("sort_order"),
+                }
+            )
+            return ['Review: clarify "world" term.']
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            _capture_generate_comments_for_spec,
+        )
+
+        run_review_job(job.id, tenant_id)
+
+        assert captured_specs
+        for spec in captured_specs:
+            _assert_full_persona_contract(spec)
+            assert spec["sort_order"] is not None
+    finally:
+        db.close()
+
+
+def test_retry_failed_persona_uses_full_persona_contract_payload(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-persona-contract-retry"
+        version, job = _seed_review_context(db, tenant_id)
+
+        persona = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
+            .order_by(models.Persona.id.asc())
+            .first()
+        )
+        assert persona is not None
+
+        captured_specs: list[dict] = []
+
+        def _capture_generate_comments_for_spec(persona_spec, _content):
+            captured_specs.append(
+                {
+                    "id": persona_spec.get("id"),
+                    "name": persona_spec.get("name"),
+                    "description": persona_spec.get("description"),
+                    "system_prompt": persona_spec.get("system_prompt"),
+                    "focus_areas": list(persona_spec.get("focus_areas") or []),
+                    "tone": persona_spec.get("tone"),
+                    "reference_notes": persona_spec.get("reference_notes"),
+                    "output_requirements": dict(persona_spec.get("output_requirements") or {}),
+                    "examples": list(persona_spec.get("examples") or []),
+                    "sort_order": persona_spec.get("sort_order"),
+                }
+            )
+            return [
+                ParsedComment(
+                    text='Clarify "world" term.',
+                    output_metadata={},
+                )
+            ]
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            _capture_generate_comments_for_spec,
+        )
+
+        added = retry_failed_persona_in_job(job.id, tenant_id, persona.id)
+        assert added == 1
+        assert len(captured_specs) == 1
+
+        spec = captured_specs[0]
+        _assert_full_persona_contract(spec)
+        assert spec["id"] == persona.id
+        assert spec["name"] == persona.name
+        assert spec["sort_order"] == persona.sort_order
+        assert spec["reference_notes"] == persona.reference_notes
+        assert spec["output_requirements"] == (persona.output_requirements or {})
+        assert spec["examples"] == (persona.examples or [])
+
+        created_comments = (
+            db.query(models.Comment)
+            .filter(
+                models.Comment.tenant_id == tenant_id,
+                models.Comment.review_job_id == job.id,
+                models.Comment.persona_id == persona.id,
+            )
+            .all()
+        )
+        assert len(created_comments) >= 1
+        assert any('Clarify "world" term.' in comment.text for comment in created_comments)
+    finally:
+        db.close()
 
 
 def test_review_worker_generates_comments_and_auto_triggers_meta(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add shared persona execution spec builder for review paths
- unify persona contract payload fields across primary review execution and retry flows
- ensure the contract includes: id, name, description, system_prompt, focus_areas, tone, reference_notes, output_requirements, examples, sort_order
- add tests proving parity and no dropped contract fields

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_review_prompt.py tests/test_personas.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/reviews/worker.py app/reviews/prompt_builder.py tests/test_review_worker.py tests/test_review_prompt.py

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved persona spec construction into reusable utilities and updated worker flows to use them, reducing inline payload assembly.

* **Tests**
  * Added unit tests for persona spec generation (field coverage, normalization, and deep-copy behavior).
  * Added integration tests validating worker job execution uses complete persona contracts and preserves expected metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->