### PR TITLE
feat(review-engine): ensure retry-path parity with primary review contract (#77)

### DIFF
--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -409,6 +409,37 @@ def _truncate_examples(examples: list[str], max_count: int, max_total_chars: int
     return trimmed, truncated
 
 
+def _normalize_output_metadata(
+    output_metadata: dict | None,
+    requirements: dict,
+    *,
+    default_violations: list[str] | None = None,
+    default_used_fallback: bool = False,
+) -> dict:
+    normalized = dict(output_metadata) if isinstance(output_metadata, dict) else {}
+
+    requirement_source = normalized.get("requirements")
+    normalized["requirements"] = normalize_output_requirements(
+        requirement_source if isinstance(requirement_source, dict) else requirements
+    )
+
+    violations_value = normalized.get("violations")
+    if isinstance(violations_value, list):
+        normalized["violations"] = [
+            str(item).strip()
+            for item in violations_value
+            if item is not None and str(item).strip()
+        ]
+    elif default_violations is not None:
+        normalized["violations"] = default_violations
+    else:
+        normalized["violations"] = []
+
+    normalized["used_fallback"] = bool(normalized.get("used_fallback", default_used_fallback))
+    normalized["truncated"] = bool(normalized.get("truncated", False))
+    return normalized
+
+
 def _normalize_parsed_comments(raw_comments: list[ParsedComment] | list[str], output_requirements: dict | None) -> list[ParsedComment]:
     if not raw_comments:
         return []
@@ -416,17 +447,25 @@ def _normalize_parsed_comments(raw_comments: list[ParsedComment] | list[str], ou
     requirements = normalize_output_requirements(output_requirements)
     for entry in raw_comments:
         if isinstance(entry, ParsedComment):
-            normalized.append(entry)
+            normalized.append(
+                ParsedComment(
+                    text=entry.text,
+                    output_metadata=_normalize_output_metadata(
+                        entry.output_metadata,
+                        requirements,
+                    ),
+                )
+            )
             continue
         normalized.append(
             ParsedComment(
                 text=str(entry),
-                output_metadata={
-                    "requirements": requirements,
-                    "violations": ["unstructured_output"],
-                    "used_fallback": True,
-                    "truncated": False,
-                },
+                output_metadata=_normalize_output_metadata(
+                    None,
+                    requirements,
+                    default_violations=["unstructured_output"],
+                    default_used_fallback=True,
+                ),
             )
         )
     return normalized
@@ -504,10 +543,31 @@ def retry_failed_persona_in_job(
         ).delete(synchronize_session=False)
         db.commit()
 
-        comments = generate_comments_for_spec(
-            build_persona_execution_spec(persona),
-            version.content,
-        )
+        spec = build_persona_execution_spec(persona)
+        try:
+            comments = _normalize_parsed_comments(
+                generate_comments_for_spec(spec, version.content),
+                spec.get("output_requirements"),
+            )
+        except Exception as exc:
+            logger.exception(
+                "retry_persona_generation_failed review_job_id=%s persona_id=%s tenant_id=%s",
+                review_job_id,
+                persona_id,
+                tenant_id,
+            )
+            comments = [
+                ParsedComment(
+                    text=f"Review failed: {exc}",
+                    output_metadata={
+                        "requirements": normalize_output_requirements(spec.get("output_requirements")),
+                        "violations": ["review_failed"],
+                        "used_fallback": True,
+                        "truncated": False,
+                    },
+                )
+            ]
+
         persist_comments(
             db,
             tenant_id,

--- a/backend/tests/test_review_worker.py
+++ b/backend/tests/test_review_worker.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from app.db import models
 from app.db.init_db import seed_default_personas
 from app.db.session import SessionLocal
-from app.reviews.parsing import ParsedComment
+from app.reviews.parsing import ParsedComment, normalize_output_requirements
 from app.reviews.prompt_builder import REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS
 from app.reviews.worker import (
     _auto_trigger_meta_synthesis,
@@ -262,6 +262,99 @@ def test_retry_failed_persona_uses_full_persona_contract_payload(monkeypatch) ->
         )
         assert len(created_comments) >= 1
         assert any('Clarify "world" term.' in comment.text for comment in created_comments)
+    finally:
+        db.close()
+
+
+def test_retry_failed_persona_normalizes_output_metadata_schema(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-persona-retry-metadata"
+        _version, job = _seed_review_context(db, tenant_id)
+
+        persona = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
+            .order_by(models.Persona.id.asc())
+            .first()
+        )
+        assert persona is not None
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            lambda _persona_spec, _content: [
+                ParsedComment(
+                    text='Clarify "world" term.',
+                    output_metadata={},
+                )
+            ],
+        )
+
+        added = retry_failed_persona_in_job(job.id, tenant_id, persona.id)
+        assert added == 1
+
+        created = (
+            db.query(models.Comment)
+            .filter(
+                models.Comment.tenant_id == tenant_id,
+                models.Comment.review_job_id == job.id,
+                models.Comment.persona_id == persona.id,
+            )
+            .order_by(models.Comment.id.desc())
+            .first()
+        )
+        assert created is not None
+        metadata = created.output_metadata
+        assert metadata["requirements"] == normalize_output_requirements(persona.output_requirements)
+        assert metadata["violations"] == []
+        assert metadata["used_fallback"] is False
+        assert metadata["truncated"] is False
+    finally:
+        db.close()
+
+
+def test_retry_failed_persona_persists_failure_fallback_metadata(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-persona-retry-fallback"
+        _version, job = _seed_review_context(db, tenant_id)
+
+        persona = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
+            .order_by(models.Persona.id.asc())
+            .first()
+        )
+        assert persona is not None
+
+        def _raise_generation_error(_persona_spec, _content):
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            _raise_generation_error,
+        )
+
+        added = retry_failed_persona_in_job(job.id, tenant_id, persona.id)
+        assert added == 1
+
+        failure_comment = (
+            db.query(models.Comment)
+            .filter(
+                models.Comment.tenant_id == tenant_id,
+                models.Comment.review_job_id == job.id,
+                models.Comment.persona_id == persona.id,
+                models.Comment.text.like("Review failed:%"),
+            )
+            .order_by(models.Comment.id.desc())
+            .first()
+        )
+        assert failure_comment is not None
+        metadata = failure_comment.output_metadata
+        assert metadata["requirements"] == normalize_output_requirements(persona.output_requirements)
+        assert metadata["violations"] == ["review_failed"]
+        assert metadata["used_fallback"] is True
+        assert metadata["truncated"] is False
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- normalize retry-path comment metadata using the same contract keys as primary review execution
- ensure retry generation output is schema-normalized before persistence
- persist retry fallback comments with normalized requirements and review_failed violation metadata when generation errors occur
- add regression tests for retry metadata normalization and retry fallback metadata behavior

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_review_parsing.py -> 15 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_comments_and_reviews.py -> 2 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/reviews/worker.py tests/test_review_worker.py -> success (no output)

Closes #77