### PR TITLE
feat(review-engine): harden prompt contract and deterministic truncation (#78)

### DIFF
--- a/backend/app/reviews/prompt_builder.py
+++ b/backend/app/reviews/prompt_builder.py
@@ -4,6 +4,7 @@ import copy
 from typing import Any
 
 from app.db import models
+from app.reviews.parsing import normalize_output_requirements
 
 REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS = (
     "id",
@@ -17,6 +18,10 @@ REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS = (
     "examples",
     "sort_order",
 )
+
+PROMPT_REFERENCE_NOTES_MAX_CHARS = 2000
+PROMPT_EXAMPLES_MAX_COUNT = 3
+PROMPT_EXAMPLES_MAX_TOTAL_CHARS = 2000
 
 
 def _normalize_focus_areas(value: Any) -> list[str]:
@@ -68,3 +73,159 @@ def build_persona_execution_spec(persona: models.Persona) -> dict[str, Any]:
 
 def build_persona_execution_specs(personas: list[models.Persona]) -> list[dict[str, Any]]:
     return [build_persona_execution_spec(persona) for persona in personas]
+
+
+def trim_prompt_content(content: str, max_chars: int) -> str:
+    if max_chars <= 0:
+        return content
+    return content[:max_chars]
+
+
+def truncate_prompt_section(
+    text: str | None,
+    *,
+    max_chars: int = PROMPT_REFERENCE_NOTES_MAX_CHARS,
+) -> tuple[str, bool]:
+    source = "" if text is None else str(text)
+    if max_chars <= 0:
+        return "", bool(source)
+    if len(source) <= max_chars:
+        return source, False
+    return source[:max_chars].rstrip(), True
+
+
+def truncate_prompt_examples(
+    examples: list[str] | None,
+    *,
+    max_count: int = PROMPT_EXAMPLES_MAX_COUNT,
+    max_total_chars: int = PROMPT_EXAMPLES_MAX_TOTAL_CHARS,
+) -> tuple[list[str], bool]:
+    normalized_examples = _normalize_examples(examples)
+    if max_count <= 0 or max_total_chars <= 0:
+        return [], bool(normalized_examples)
+
+    trimmed: list[str] = []
+    total = 0
+    truncated = len(normalized_examples) > max_count
+
+    for example in normalized_examples[:max_count]:
+        remaining = max_total_chars - total
+        if remaining <= 0:
+            truncated = True
+            break
+
+        text = example
+        if len(text) > remaining:
+            text = text[:remaining].rstrip()
+            truncated = True
+
+        if not text:
+            truncated = True
+            continue
+
+        total += len(text)
+        trimmed.append(f"- {text}")
+
+    return trimmed, truncated
+
+
+def build_review_prompt(
+    name: str,
+    description: str | None,
+    system_prompt: str | None,
+    focus_areas: list[str] | None,
+    tone: str | None,
+    content: str,
+    reference_notes: str | None = None,
+    output_requirements: dict | None = None,
+    examples: list[str] | None = None,
+    *,
+    reference_notes_max_chars: int = PROMPT_REFERENCE_NOTES_MAX_CHARS,
+    examples_max_count: int = PROMPT_EXAMPLES_MAX_COUNT,
+    examples_max_total_chars: int = PROMPT_EXAMPLES_MAX_TOTAL_CHARS,
+) -> str:
+    normalized_focus_areas = _normalize_focus_areas(focus_areas)
+    focus = ", ".join(normalized_focus_areas) if normalized_focus_areas else "general quality"
+
+    voice = "direct and constructive"
+    if tone is not None:
+        candidate = str(tone).strip()
+        if candidate:
+            voice = candidate
+
+    summary = description or ""
+    requirements = normalize_output_requirements(output_requirements)
+    include_severity = requirements["include_severity"]
+
+    sections = [
+        "You are a document review persona.",
+        f"Name: {name}",
+        f"Description: {summary}",
+        f"System prompt: {system_prompt or ''}",
+        f"Focus areas: {focus}",
+        f"Tone: {voice}",
+        "",
+        "Output requirements:",
+        f"- Format: {requirements['format']}",
+        f"- Max bullets: {requirements['max_bullets']}",
+        f"- Require quote excerpt: {'yes' if requirements['require_quote_excerpt'] else 'no'}",
+        f"- Require actionable recommendation: {'yes' if requirements['require_actionable'] else 'no'}",
+        f"- Include severity tags: {'yes' if include_severity else 'no'}",
+        "",
+        "Formatting constraints:",
+    ]
+
+    if requirements["format"] == "bullet_list":
+        example_prefix = (
+            "- [high] \"<exact excerpt>\" :: <actionable comment>"
+            if include_severity
+            else "- \"<exact excerpt>\" :: <actionable comment>"
+        )
+        sections.extend(
+            [
+                "Use Markdown bullets that start with '- '.",
+                f"Example bullet: {example_prefix}",
+            ]
+        )
+    else:
+        sections.append("Provide a single response matching the required format above.")
+
+    if requirements["require_quote_excerpt"]:
+        sections.append("When quote excerpts are required, use exact document text inside double quotes.")
+    if requirements["require_actionable"]:
+        sections.append("When actionable recommendations are required, include a concrete next step.")
+
+    cleaned_notes = ""
+    if reference_notes is not None:
+        cleaned_notes = str(reference_notes).strip()
+    if cleaned_notes:
+        truncated_notes, notes_truncated = truncate_prompt_section(
+            cleaned_notes,
+            max_chars=reference_notes_max_chars,
+        )
+        sections.append("")
+        sections.append("Reference notes (always consider):")
+        sections.append(truncated_notes)
+        if notes_truncated:
+            sections.append(f"(Reference notes were truncated to {reference_notes_max_chars} characters.)")
+
+    trimmed_examples, examples_truncated = truncate_prompt_examples(
+        examples,
+        max_count=examples_max_count,
+        max_total_chars=examples_max_total_chars,
+    )
+    if trimmed_examples:
+        sections.append("")
+        sections.append("Examples:")
+        sections.extend(trimmed_examples)
+        if examples_truncated:
+            sections.append("(Examples were truncated to fit size limits.)")
+
+    sections.extend(
+        [
+            "",
+            "Document:",
+            content,
+        ]
+    )
+    return "\n".join(sections)

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -11,7 +11,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout, as_completed
 from app.reviews.meta_reviewer import ensure_meta_review_run
 from app.reviews.parsing import parse_review_output, persist_comment_payloads, normalize_output_requirements, ParsedComment
-from app.reviews.prompt_builder import build_persona_execution_spec, build_persona_execution_specs
+from app.reviews.prompt_builder import (
+    build_persona_execution_spec,
+    build_persona_execution_specs,
+    build_review_prompt,
+    trim_prompt_content,
+)
 from app.reviews.git_repo import ensure_repo
 from app.reviews.review_storage import write_review_and_commit
 from datetime import datetime, timezone
@@ -302,111 +307,21 @@ def build_prompt(
     output_requirements: dict | None = None,
     examples: list[str] | None = None,
 ) -> str:
-    clean_focus_areas = []
-    for item in focus_areas or []:
-        if item is None:
-            continue
-        text = str(item).strip()
-        if text:
-            clean_focus_areas.append(text)
-    focus = ", ".join(clean_focus_areas) if clean_focus_areas else "general quality"
-    voice = tone or "direct and constructive"
-    summary = description or ""
-    requirements = normalize_output_requirements(output_requirements)
-    max_bullets = requirements["max_bullets"]
-    include_severity = requirements["include_severity"]
-
-    sections = [
-        "You are a document review persona.",
-        f"Name: {name}",
-        f"Description: {summary}",
-        f"System prompt: {system_prompt or ''}",
-        f"Focus areas: {focus}",
-        f"Tone: {voice}",
-        "",
-        "Output requirements:",
-        f"- Format: {requirements['format']}",
-        f"- Max bullets: {max_bullets}",
-    ]
-    if requirements["require_quote_excerpt"]:
-        sections.append("- Each bullet must include an exact excerpt from the document in double quotes.")
-    if requirements["require_actionable"]:
-        sections.append("- Each bullet must include an actionable recommendation.")
-    if include_severity:
-        sections.append("- Prefix each bullet with a severity tag: [low], [medium], or [high].")
-
-    if requirements["format"] == "bullet_list":
-        example_prefix = "- [high] \"<exact excerpt>\" :: <actionable comment>" if include_severity else "- \"<exact excerpt>\" :: <actionable comment>"
-        sections.extend(
-            [
-                "Use Markdown bullets that start with '- '.",
-                f"Example: {example_prefix}",
-            ]
-        )
-    else:
-        sections.append("Provide a single response matching the required format above.")
-
-    if reference_notes:
-        truncated_notes, notes_truncated = _truncate_section(reference_notes, 2000)
-        sections.append("")
-        sections.append("Reference notes (always consider):")
-        sections.append(truncated_notes)
-        if notes_truncated:
-            sections.append("(Reference notes were truncated to 2000 characters.)")
-
-    if examples:
-        trimmed_examples, examples_truncated = _truncate_examples(examples, 3, 2000)
-        if trimmed_examples:
-            sections.append("")
-            sections.append("Examples:")
-            sections.extend(trimmed_examples)
-            if examples_truncated:
-                sections.append("(Examples were truncated to fit size limits.)")
-
-    sections.extend(
-        [
-            "",
-            "Document:",
-            content,
-        ]
+    return build_review_prompt(
+        name=name,
+        description=description,
+        system_prompt=system_prompt,
+        focus_areas=focus_areas,
+        tone=tone,
+        content=content,
+        reference_notes=reference_notes,
+        output_requirements=output_requirements,
+        examples=examples,
     )
-    return "\n".join(sections)
 
 
 def trim_content(content: str) -> str:
-    if settings.OPENAI_MAX_INPUT_CHARS <= 0:
-        return content
-    return content[: settings.OPENAI_MAX_INPUT_CHARS]
-
-
-def _truncate_section(text: str, max_chars: int) -> tuple[str, bool]:
-    if len(text) <= max_chars:
-        return text, False
-    return text[:max_chars].rstrip(), True
-
-
-def _truncate_examples(examples: list[str], max_count: int, max_total_chars: int) -> tuple[list[str], bool]:
-    trimmed: list[str] = []
-    total = 0
-    truncated = False
-    for example in examples[:max_count]:
-        if example is None:
-            continue
-        text = str(example).strip()
-        if not text:
-            continue
-        remaining = max_total_chars - total
-        if remaining <= 0:
-            truncated = True
-            break
-        if len(text) > remaining:
-            text = text[:remaining].rstrip()
-            truncated = True
-        total += len(text)
-        trimmed.append(f"- {text}")
-    if len(examples) > max_count:
-        truncated = True
-    return trimmed, truncated
+    return trim_prompt_content(content, settings.OPENAI_MAX_INPUT_CHARS)
 
 
 def _normalize_output_metadata(

--- a/backend/tests/fixtures/review_prompt/contract_snapshot.txt
+++ b/backend/tests/fixtures/review_prompt/contract_snapshot.txt
@@ -1,0 +1,28 @@
+You are a document review persona.
+Name: Snapshot Persona
+Description: Checks deterministic prompt assembly.
+System prompt: Review for clarity and risk.
+Focus areas: clarity, risk
+Tone: direct and constructive
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 3
+- Require quote excerpt: yes
+- Require actionable recommendation: yes
+- Include severity tags: yes
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - [high] "<exact excerpt>" :: <actionable comment>
+When quote excerpts are required, use exact document text inside double quotes.
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+Always cite policy before recommending edits.
+
+Examples:
+- [high] "token" :: define expiration behavior
+
+Document:
+Document body for snapshot.

--- a/backend/tests/fixtures/review_prompt/truncation_snapshot.txt
+++ b/backend/tests/fixtures/review_prompt/truncation_snapshot.txt
@@ -1,0 +1,30 @@
+You are a document review persona.
+Name: Truncation Persona
+Description: Verifies deterministic truncation.
+System prompt: Follow output contract.
+Focus areas: risk
+Tone: careful
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 2
+- Require quote excerpt: no
+- Require actionable recommendation: yes
+- Include severity tags: no
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - "<exact excerpt>" :: <actionable comment>
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+abcdefghij
+(Reference notes were truncated to 10 characters.)
+
+Examples:
+- ABCDEFGHIJKL
+- MNO
+(Examples were truncated to fit size limits.)
+
+Document:
+01234567

--- a/backend/tests/test_review_prompt.py
+++ b/backend/tests/test_review_prompt.py
@@ -1,13 +1,24 @@
+from pathlib import Path
+
 from app.db import models
 from app.reviews.prompt_builder import (
     REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS,
     build_persona_execution_spec,
+    build_review_prompt,
+    trim_prompt_content,
+    truncate_prompt_examples,
+    truncate_prompt_section,
 )
-from app.reviews.worker import build_prompt
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "review_prompt"
 
 
-def test_build_prompt_handles_none_focus_items() -> None:
-    prompt = build_prompt(
+def _load_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_build_review_prompt_handles_none_focus_items() -> None:
+    prompt = build_review_prompt(
         name="Risk Reviewer",
         description=None,
         system_prompt=None,
@@ -16,6 +27,110 @@ def test_build_prompt_handles_none_focus_items() -> None:
         content="Sample content",
     )
     assert "Focus areas: security, compliance" in prompt
+
+
+def test_build_review_prompt_renders_output_requirements_and_formatting_constraints() -> None:
+    prompt = build_review_prompt(
+        name="Risk Reviewer",
+        description="reviews risk",
+        system_prompt="Be explicit.",
+        focus_areas=["risk"],
+        tone="direct",
+        content="Sample content",
+        output_requirements={
+            "format": "bullet_list",
+            "max_bullets": 2,
+            "require_quote_excerpt": True,
+            "require_actionable": False,
+            "include_severity": True,
+        },
+    )
+
+    assert "Output requirements:" in prompt
+    assert "- Format: bullet_list" in prompt
+    assert "- Max bullets: 2" in prompt
+    assert "- Require quote excerpt: yes" in prompt
+    assert "- Require actionable recommendation: no" in prompt
+    assert "- Include severity tags: yes" in prompt
+    assert "Formatting constraints:" in prompt
+    assert "Use Markdown bullets that start with '- '." in prompt
+    assert "Example bullet: - [high] \"<exact excerpt>\" :: <actionable comment>" in prompt
+    assert "When quote excerpts are required, use exact document text inside double quotes." in prompt
+    assert "When actionable recommendations are required, include a concrete next step." not in prompt
+
+
+def test_trim_prompt_content_is_deterministic() -> None:
+    assert trim_prompt_content("abcdef", max_chars=-1) == "abcdef"
+    assert trim_prompt_content("abcdef", max_chars=0) == "abcdef"
+    assert trim_prompt_content("abcdef", max_chars=3) == "abc"
+    assert trim_prompt_content("abc", max_chars=3) == "abc"
+
+
+def test_truncate_prompt_section_is_deterministic() -> None:
+    text, truncated = truncate_prompt_section("abcdef", max_chars=4)
+    assert text == "abcd"
+    assert truncated is True
+
+    text, truncated = truncate_prompt_section("abc", max_chars=4)
+    assert text == "abc"
+    assert truncated is False
+
+
+def test_truncate_prompt_examples_is_deterministic() -> None:
+    examples, truncated = truncate_prompt_examples(
+        ["ABCDEFGHIJKL", "MNOPQRSTUV", "WXYZ"],
+        max_count=2,
+        max_total_chars=15,
+    )
+    assert examples == ["- ABCDEFGHIJKL", "- MNO"]
+    assert truncated is True
+
+
+def test_build_review_prompt_contract_snapshot() -> None:
+    prompt = build_review_prompt(
+        name="Snapshot Persona",
+        description="Checks deterministic prompt assembly.",
+        system_prompt="Review for clarity and risk.",
+        focus_areas=["clarity", "risk"],
+        tone="direct and constructive",
+        content="Document body for snapshot.",
+        reference_notes="Always cite policy before recommending edits.",
+        output_requirements={
+            "format": "bullet_list",
+            "max_bullets": 3,
+            "require_quote_excerpt": True,
+            "require_actionable": True,
+            "include_severity": True,
+        },
+        examples=['[high] "token" :: define expiration behavior'],
+    )
+
+    assert prompt == _load_fixture("contract_snapshot.txt")
+
+
+def test_build_review_prompt_truncation_snapshot() -> None:
+    prompt = build_review_prompt(
+        name="Truncation Persona",
+        description="Verifies deterministic truncation.",
+        system_prompt="Follow output contract.",
+        focus_areas=["risk"],
+        tone="careful",
+        content=trim_prompt_content("0123456789ABCDE", max_chars=8),
+        reference_notes="abcdefghijklmno",
+        output_requirements={
+            "format": "bullet_list",
+            "max_bullets": 2,
+            "require_quote_excerpt": False,
+            "require_actionable": True,
+            "include_severity": False,
+        },
+        examples=["ABCDEFGHIJKL", "MNOPQRSTUV", "WXYZ"],
+        reference_notes_max_chars=10,
+        examples_max_count=2,
+        examples_max_total_chars=15,
+    )
+
+    assert prompt == _load_fixture("truncation_snapshot.txt")
 
 
 def test_build_persona_execution_spec_includes_all_required_contract_fields() -> None:


### PR DESCRIPTION
## Summary
- move prompt assembly into app/reviews/prompt_builder.py as build_review_prompt with deterministic contract rendering
- render output requirements and formatting constraints consistently, including explicit yes or no flags for quote excerpt, actionable recommendations, and severity tags
- make truncation behavior deterministic and reusable for content, reference notes, and examples via trim_prompt_content, truncate_prompt_section, and truncate_prompt_examples
- add prompt snapshot fixtures to catch regressions in required prompt contract sections and truncation messaging
- keep worker API compatibility by preserving build_prompt and trim_content wrappers in app/reviews/worker.py

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_prompt.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_review_parsing.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/reviews/prompt_builder.py app/reviews/worker.py tests/test_review_prompt.py

Closes #78