### PR TITLE
feat(review-engine): standardize parser violation taxonomy and metadata normalization (#79)

### DIFF
--- a/backend/app/crud/comment.py
+++ b/backend/app/crud/comment.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
 from app.db import models
+from app.reviews.parsing import normalize_comment_output_metadata
 from app.schemas.comment import CommentCreate
 
 
@@ -14,7 +15,7 @@ def create_comment(db: Session, tenant_id: str, data: CommentCreate) -> models.C
         start_offset=data.start_offset,
         end_offset=data.end_offset,
         excerpt=data.excerpt,
-        output_metadata=data.output_metadata or {},
+        output_metadata=normalize_comment_output_metadata(data.output_metadata),
     )
     db.add(comment)
     db.commit()
@@ -37,4 +38,7 @@ def list_comments_by_version(
     )
     if review_job_id is not None:
         query = query.filter(models.Comment.review_job_id == review_job_id)
-    return query.order_by(models.Comment.id.asc()).all()
+    comments = query.order_by(models.Comment.id.asc()).all()
+    for comment in comments:
+        comment.output_metadata = normalize_comment_output_metadata(comment.output_metadata)
+    return comments

--- a/backend/app/reviews/parsing.py
+++ b/backend/app/reviews/parsing.py
@@ -12,6 +12,41 @@ DEFAULT_OUTPUT_REQUIREMENTS = {
     "include_severity": False,
 }
 
+VIOLATION_MISSING_QUOTE_EXCERPT = "missing_quote_excerpt"
+VIOLATION_MISSING_ACTIONABLE = "missing_actionable"
+VIOLATION_MISSING_SEVERITY = "missing_severity"
+VIOLATION_UNSTRUCTURED_OUTPUT = "unstructured_output"
+VIOLATION_TRUNCATED_OUTPUT = "truncated_output"
+VIOLATION_REVIEW_FAILED = "review_failed"
+
+CANONICAL_VIOLATION_TAXONOMY = (
+    VIOLATION_MISSING_QUOTE_EXCERPT,
+    VIOLATION_MISSING_ACTIONABLE,
+    VIOLATION_MISSING_SEVERITY,
+    VIOLATION_UNSTRUCTURED_OUTPUT,
+    VIOLATION_TRUNCATED_OUTPUT,
+    VIOLATION_REVIEW_FAILED,
+)
+
+REQUIRED_OUTPUT_METADATA_KEYS = (
+    "requirements",
+    "violations",
+    "used_fallback",
+    "truncated",
+)
+
+LEGACY_VIOLATION_ALIASES = {
+    "missing_quote": VIOLATION_MISSING_QUOTE_EXCERPT,
+    "missing_quote_text": VIOLATION_MISSING_QUOTE_EXCERPT,
+    "missing_action": VIOLATION_MISSING_ACTIONABLE,
+    "missing_severity_tag": VIOLATION_MISSING_SEVERITY,
+    "severity_missing": VIOLATION_MISSING_SEVERITY,
+    "unstructured": VIOLATION_UNSTRUCTURED_OUTPUT,
+    "truncated": VIOLATION_TRUNCATED_OUTPUT,
+    "failed_review": VIOLATION_REVIEW_FAILED,
+    "review_error": VIOLATION_REVIEW_FAILED,
+}
+
 SEVERITY_PATTERN = re.compile(r"^\s*\[(low|medium|high)\]", re.IGNORECASE)
 
 
@@ -39,6 +74,39 @@ def normalize_output_requirements(requirements: dict | None) -> dict:
     return normalized
 
 
+def normalize_comment_output_metadata(
+    output_metadata: dict | None,
+    output_requirements: dict | None = None,
+    *,
+    default_violations: list[str] | None = None,
+    default_used_fallback: bool = False,
+    default_truncated: bool = False,
+) -> dict:
+    normalized = dict(output_metadata) if isinstance(output_metadata, dict) else {}
+
+    requirements_source = normalized.get("requirements")
+    normalized["requirements"] = normalize_output_requirements(
+        requirements_source if isinstance(requirements_source, dict) else output_requirements
+    )
+
+    violations_source = normalized.get("violations")
+    if isinstance(violations_source, list):
+        violations = _normalize_violation_list(violations_source)
+    elif default_violations is not None:
+        violations = _normalize_violation_list(default_violations)
+    else:
+        violations = []
+
+    normalized["used_fallback"] = _coerce_bool(normalized.get("used_fallback"), default_used_fallback)
+    normalized["truncated"] = _coerce_bool(normalized.get("truncated"), default_truncated)
+
+    if normalized["truncated"] and VIOLATION_TRUNCATED_OUTPUT not in violations:
+        violations.append(VIOLATION_TRUNCATED_OUTPUT)
+
+    normalized["violations"] = violations
+    return normalized
+
+
 def parse_bullets(text: str) -> list[str]:
     bullets: list[str] = []
     for line in text.splitlines():
@@ -58,6 +126,8 @@ def parse_review_output(text: str, output_requirements: dict | None = None) -> l
     use_bullets = requirements["format"] == "bullet_list"
     used_fallback = False
     raw_items: list[str] = []
+    fallback_violations: list[str] = []
+
     if use_bullets:
         bullet_items: list[str] = []
         for line in text.splitlines():
@@ -73,6 +143,7 @@ def parse_review_output(text: str, output_requirements: dict | None = None) -> l
             if stripped:
                 raw_items = [stripped]
                 used_fallback = True
+                fallback_violations = [VIOLATION_UNSTRUCTURED_OUTPUT]
     else:
         stripped = text.strip()
         if stripped:
@@ -86,19 +157,23 @@ def parse_review_output(text: str, output_requirements: dict | None = None) -> l
 
     parsed: list[ParsedComment] = []
     for item in raw_items:
-        violations: list[str] = []
+        violations = list(fallback_violations)
         if requirements["require_quote_excerpt"] and not _has_quote_excerpt(item):
-            violations.append("missing_quote_excerpt")
+            violations.append(VIOLATION_MISSING_QUOTE_EXCERPT)
         if requirements["require_actionable"] and not _looks_actionable(item):
-            violations.append("missing_actionable")
+            violations.append(VIOLATION_MISSING_ACTIONABLE)
         if requirements["include_severity"] and not SEVERITY_PATTERN.search(item):
-            violations.append("missing_severity")
-        output_metadata = {
-            "requirements": requirements,
-            "violations": violations,
-            "used_fallback": used_fallback,
-            "truncated": truncated,
-        }
+            violations.append(VIOLATION_MISSING_SEVERITY)
+
+        output_metadata = normalize_comment_output_metadata(
+            {
+                "requirements": requirements,
+                "violations": violations,
+                "used_fallback": used_fallback,
+                "truncated": truncated,
+            },
+            requirements,
+        )
         parsed.append(ParsedComment(text=item, output_metadata=output_metadata))
     return parsed
 
@@ -149,8 +224,46 @@ def persist_comment_payloads(
         if not normalized:
             continue
         excerpt, start, end = extract_excerpt(content, normalized)
-        payloads.append((normalized, excerpt, start, end, comment.output_metadata))
+        payloads.append(
+            (
+                normalized,
+                excerpt,
+                start,
+                end,
+                normalize_comment_output_metadata(comment.output_metadata),
+            )
+        )
     return payloads
+
+
+def _normalize_violation_list(values: Iterable[object]) -> list[str]:
+    normalized: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        token = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+        if not token:
+            continue
+        token = LEGACY_VIOLATION_ALIASES.get(token, token)
+        if token not in normalized:
+            normalized.append(token)
+    return normalized
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "f", "no", "n", "off", ""}:
+            return False
+    return bool(value)
 
 
 def _has_quote_excerpt(comment: str) -> bool:

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -10,7 +10,15 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout, as_completed
 from app.reviews.meta_reviewer import ensure_meta_review_run
-from app.reviews.parsing import parse_review_output, persist_comment_payloads, normalize_output_requirements, ParsedComment
+from app.reviews.parsing import (
+    ParsedComment,
+    VIOLATION_REVIEW_FAILED,
+    VIOLATION_UNSTRUCTURED_OUTPUT,
+    normalize_comment_output_metadata,
+    normalize_output_requirements,
+    parse_review_output,
+    persist_comment_payloads,
+)
 from app.reviews.prompt_builder import (
     build_persona_execution_spec,
     build_persona_execution_specs,
@@ -170,7 +178,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                         text=f"Review failed: {exc}",
                         output_metadata={
                             "requirements": normalize_output_requirements(spec.get("output_requirements")),
-                            "violations": ["review_failed"],
+                            "violations": [VIOLATION_REVIEW_FAILED],
                             "used_fallback": True,
                             "truncated": False,
                         },
@@ -331,28 +339,12 @@ def _normalize_output_metadata(
     default_violations: list[str] | None = None,
     default_used_fallback: bool = False,
 ) -> dict:
-    normalized = dict(output_metadata) if isinstance(output_metadata, dict) else {}
-
-    requirement_source = normalized.get("requirements")
-    normalized["requirements"] = normalize_output_requirements(
-        requirement_source if isinstance(requirement_source, dict) else requirements
+    return normalize_comment_output_metadata(
+        output_metadata,
+        requirements,
+        default_violations=default_violations,
+        default_used_fallback=default_used_fallback,
     )
-
-    violations_value = normalized.get("violations")
-    if isinstance(violations_value, list):
-        normalized["violations"] = [
-            str(item).strip()
-            for item in violations_value
-            if item is not None and str(item).strip()
-        ]
-    elif default_violations is not None:
-        normalized["violations"] = default_violations
-    else:
-        normalized["violations"] = []
-
-    normalized["used_fallback"] = bool(normalized.get("used_fallback", default_used_fallback))
-    normalized["truncated"] = bool(normalized.get("truncated", False))
-    return normalized
 
 
 def _normalize_parsed_comments(raw_comments: list[ParsedComment] | list[str], output_requirements: dict | None) -> list[ParsedComment]:
@@ -378,7 +370,7 @@ def _normalize_parsed_comments(raw_comments: list[ParsedComment] | list[str], ou
                 output_metadata=_normalize_output_metadata(
                     None,
                     requirements,
-                    default_violations=["unstructured_output"],
+                    default_violations=[VIOLATION_UNSTRUCTURED_OUTPUT],
                     default_used_fallback=True,
                 ),
             )
@@ -476,7 +468,7 @@ def retry_failed_persona_in_job(
                     text=f"Review failed: {exc}",
                     output_metadata={
                         "requirements": normalize_output_requirements(spec.get("output_requirements")),
-                        "violations": ["review_failed"],
+                        "violations": [VIOLATION_REVIEW_FAILED],
                         "used_fallback": True,
                         "truncated": False,
                     },

--- a/backend/tests/test_comments_and_reviews.py
+++ b/backend/tests/test_comments_and_reviews.py
@@ -1,3 +1,6 @@
+from app.reviews.parsing import REQUIRED_OUTPUT_METADATA_KEYS, VIOLATION_MISSING_QUOTE_EXCERPT, VIOLATION_TRUNCATED_OUTPUT
+
+
 def test_comments_and_review_jobs(client, monkeypatch) -> None:
     def _noop_enqueue(job_id: int, tenant_id: str) -> None:
         return None
@@ -58,6 +61,73 @@ def test_comments_and_review_jobs(client, monkeypatch) -> None:
     )
     assert list_comments.status_code == 200
     assert len(list_comments.json()) == 1
+
+
+def test_comments_endpoint_normalizes_legacy_output_metadata(client, monkeypatch) -> None:
+    def _noop_enqueue(job_id: int, tenant_id: str) -> None:
+        return None
+
+    monkeypatch.setattr("app.api.review_jobs.enqueue_review_job", _noop_enqueue)
+    headers = {"X-Tenant-Id": "tenant-legacy-meta"}
+
+    persona_resp = client.post(
+        "/api/personas",
+        json={
+            "name": "Legacy Meta Persona",
+            "description": "legacy",
+            "system_prompt": "legacy",
+            "focus_areas": ["risk"],
+            "tone": "direct",
+            "is_active": True,
+            "group_id": None,
+        },
+        headers=headers,
+    )
+    assert persona_resp.status_code == 201
+    persona_id = persona_resp.json()["id"]
+
+    doc_resp = client.post("/api/documents", json={"title": "Legacy Doc"}, headers=headers)
+    assert doc_resp.status_code == 201
+    doc_id = doc_resp.json()["id"]
+
+    version_resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        json={"version_label": "v1", "content": "legacy content"},
+        headers=headers,
+    )
+    assert version_resp.status_code == 201
+    version_id = version_resp.json()["id"]
+
+    create_resp = client.post(
+        "/api/comments",
+        json={
+            "persona_id": persona_id,
+            "document_version_id": version_id,
+            "text": "Needs better structure.",
+            "start_offset": 0,
+            "end_offset": 5,
+            "excerpt": "legacy",
+            "output_metadata": {
+                "violations": ["missing_quote", "truncated"],
+                "legacy_field": "kept",
+                "truncated": 1,
+            },
+        },
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+
+    created_meta = create_resp.json()["output_metadata"]
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(created_meta.keys())
+    assert VIOLATION_MISSING_QUOTE_EXCERPT in created_meta["violations"]
+    assert VIOLATION_TRUNCATED_OUTPUT in created_meta["violations"]
+    assert created_meta["legacy_field"] == "kept"
+
+    listed = client.get(f"/api/comments?document_version_id={version_id}", headers=headers)
+    assert listed.status_code == 200
+    listed_meta = listed.json()[0]["output_metadata"]
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(listed_meta.keys())
+    assert listed_meta["legacy_field"] == "kept"
 
 
 def test_retry_failed_persona_endpoint(client, monkeypatch) -> None:

--- a/backend/tests/test_parsing.py
+++ b/backend/tests/test_parsing.py
@@ -1,4 +1,13 @@
-from app.reviews.parsing import normalize_comment_text, persist_comment_payloads, ParsedComment
+from app.reviews.parsing import (
+    REQUIRED_OUTPUT_METADATA_KEYS,
+    ParsedComment,
+    VIOLATION_MISSING_QUOTE_EXCERPT,
+    VIOLATION_REVIEW_FAILED,
+    VIOLATION_TRUNCATED_OUTPUT,
+    normalize_comment_output_metadata,
+    normalize_comment_text,
+    persist_comment_payloads,
+)
 
 
 def test_normalize_comment_text_strips_empty_quote_prefix() -> None:
@@ -13,3 +22,30 @@ def test_persist_comment_payloads_uses_normalized_text() -> None:
     assert len(payloads) == 1
     comment, _excerpt, _start, _end, _meta = payloads[0]
     assert comment == "clarify token expiration behavior"
+
+
+def test_persist_comment_payloads_normalizes_output_metadata_keys() -> None:
+    content = "Token expiration behavior must be explicit."
+    comments = [ParsedComment(text="clarify token expiration behavior", output_metadata={"legacy": "value"})]
+    payloads = persist_comment_payloads(comments, content)
+    assert len(payloads) == 1
+    _comment, _excerpt, _start, _end, metadata = payloads[0]
+    assert metadata["legacy"] == "value"
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(metadata.keys())
+
+
+def test_normalize_comment_output_metadata_maps_legacy_violations() -> None:
+    normalized = normalize_comment_output_metadata(
+        {
+            "violations": ["missing_quote", "review_error", "truncated"],
+            "used_fallback": "yes",
+            "truncated": 1,
+        }
+    )
+
+    assert VIOLATION_MISSING_QUOTE_EXCERPT in normalized["violations"]
+    assert VIOLATION_REVIEW_FAILED in normalized["violations"]
+    assert VIOLATION_TRUNCATED_OUTPUT in normalized["violations"]
+    assert normalized["used_fallback"] is True
+    assert normalized["truncated"] is True
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(normalized.keys())

--- a/backend/tests/test_review_parsing.py
+++ b/backend/tests/test_review_parsing.py
@@ -1,20 +1,31 @@
-from app.reviews.parsing import extract_excerpt, parse_review_output
+from app.reviews.parsing import (
+    REQUIRED_OUTPUT_METADATA_KEYS,
+    VIOLATION_MISSING_QUOTE_EXCERPT,
+    VIOLATION_MISSING_SEVERITY,
+    VIOLATION_TRUNCATED_OUTPUT,
+    VIOLATION_UNSTRUCTURED_OUTPUT,
+    extract_excerpt,
+    parse_review_output,
+)
 
 
-def test_parse_review_output_extracts_lines():
+def test_parse_review_output_extracts_lines() -> None:
     text = "- First point\n- Second point\nTrailing"
     parsed = parse_review_output(text, {"max_bullets": 4})
     assert [item.text for item in parsed] == ["First point", "Second point"]
 
 
-def test_parse_review_output_falls_back_to_text():
+def test_parse_review_output_falls_back_to_text() -> None:
     text = "Single paragraph review."
     parsed = parse_review_output(text, {"max_bullets": 4})
     assert [item.text for item in parsed] == ["Single paragraph review."]
-    assert parsed[0].output_metadata["used_fallback"] is True
+    metadata = parsed[0].output_metadata
+    assert metadata["used_fallback"] is True
+    assert VIOLATION_UNSTRUCTURED_OUTPUT in metadata["violations"]
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(metadata.keys())
 
 
-def test_parse_review_output_flags_missing_quote_and_severity():
+def test_parse_review_output_flags_missing_quote_and_severity() -> None:
     text = "- Needs work"
     parsed = parse_review_output(
         text,
@@ -25,11 +36,29 @@ def test_parse_review_output_flags_missing_quote_and_severity():
             "include_severity": True,
         },
     )
-    assert "missing_quote_excerpt" in parsed[0].output_metadata["violations"]
-    assert "missing_severity" in parsed[0].output_metadata["violations"]
+    assert VIOLATION_MISSING_QUOTE_EXCERPT in parsed[0].output_metadata["violations"]
+    assert VIOLATION_MISSING_SEVERITY in parsed[0].output_metadata["violations"]
 
 
-def test_extract_excerpt_finds_offset():
+def test_parse_review_output_adds_truncated_output_violation() -> None:
+    parsed = parse_review_output(
+        "- one\n- two\n- three",
+        {
+            "max_bullets": 2,
+            "require_quote_excerpt": False,
+            "require_actionable": False,
+            "include_severity": False,
+        },
+    )
+    assert len(parsed) == 2
+    for item in parsed:
+        metadata = item.output_metadata
+        assert metadata["truncated"] is True
+        assert VIOLATION_TRUNCATED_OUTPUT in metadata["violations"]
+        assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(metadata.keys())
+
+
+def test_extract_excerpt_finds_offset() -> None:
     content = "Hello world, this is a test."
     comment = "Consider replacing \"world\" with audience."
     excerpt, start, end = extract_excerpt(content, comment)


### PR DESCRIPTION
## Summary
- standardize parser violation taxonomy constants and alias normalization for legacy violation names
- guarantee output metadata normalization with required keys: requirements, violations, used_fallback, truncated
- add parser-level taxonomy behavior for unstructured_output and truncated_output where applicable
- normalize persisted comment metadata payloads and comment CRUD read/write paths for backward-compatible handling of legacy metadata missing keys
- keep worker normalization behavior aligned by delegating to parser metadata normalization

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_parsing.py tests/test_parsing.py tests/test_comments_and_reviews.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_documents.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/reviews/parsing.py app/reviews/worker.py app/crud/comment.py tests/test_review_parsing.py tests/test_parsing.py tests/test_comments_and_reviews.py

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment metadata is now standardized with canonical violation categories for improved consistency across the system.

* **Bug Fixes**
  * Legacy comment metadata formats are automatically normalized during comment creation and retrieval operations.

* **Tests**
  * Added comprehensive tests to validate metadata normalization and legacy format handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->