### PR TITLE
feat(review-engine): persist review-quality telemetry with atomic completion updates (#80)

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -32,6 +32,10 @@ from app.schemas.document_version import DocumentVersionCreate, DocumentVersionR
 from app.schemas.review_bundle import ReviewBundleImport, ReviewBundleImportResult
 from app.reviews.git_repo import ensure_repo
 from app.reviews.git_history import list_commits
+from app.reviews.quality_telemetry import (
+    build_empty_review_quality_telemetry,
+    normalize_review_quality_telemetry,
+)
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -273,6 +277,9 @@ def import_bundle(
             trigger=payload.review_job.trigger,
             provider=payload.review_job.provider,
             model=payload.review_job.model,
+            quality_telemetry=normalize_review_quality_telemetry(payload.review_job.quality_telemetry)
+            if payload.review_job.quality_telemetry is not None
+            else build_empty_review_quality_telemetry(),
         )
         if payload.review_job.created_at is not None:
             review_job_data["created_at"] = payload.review_job.created_at

--- a/backend/app/crud/review_job.py
+++ b/backend/app/crud/review_job.py
@@ -2,6 +2,10 @@ from sqlalchemy.orm import Session
 
 from app.db import models
 from app.reviews.llm_provider import get_model_label, get_provider_name
+from app.reviews.quality_telemetry import (
+    build_empty_review_quality_telemetry,
+    normalize_review_quality_telemetry,
+)
 from app.schemas.review_job import ReviewJobCreate
 
 
@@ -13,6 +17,7 @@ def create_job(db: Session, tenant_id: str, data: ReviewJobCreate) -> models.Rev
         trigger=data.trigger or "auto",
         provider=get_provider_name(),
         model=get_model_label(),
+        quality_telemetry=build_empty_review_quality_telemetry(),
     )
     db.add(job)
     db.commit()
@@ -26,13 +31,16 @@ def list_jobs(
     query = db.query(models.ReviewJob).filter(models.ReviewJob.tenant_id == tenant_id)
     if document_version_id is not None:
         query = query.filter(models.ReviewJob.document_version_id == document_version_id)
-    return query.order_by(models.ReviewJob.id.asc()).all()
+    jobs = query.order_by(models.ReviewJob.id.asc()).all()
+    for job in jobs:
+        job.quality_telemetry = normalize_review_quality_telemetry(job.quality_telemetry)
+    return jobs
 
 
 def get_latest_job_for_version(
     db: Session, tenant_id: str, document_version_id: int
 ) -> models.ReviewJob | None:
-    return (
+    job = (
         db.query(models.ReviewJob)
         .filter(
             models.ReviewJob.tenant_id == tenant_id,
@@ -41,3 +49,6 @@ def get_latest_job_for_version(
         .order_by(models.ReviewJob.id.desc())
         .first()
     )
+    if job is not None:
+        job.quality_telemetry = normalize_review_quality_telemetry(job.quality_telemetry)
+    return job

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -263,6 +263,7 @@ def _ensure_schema() -> None:
             "completed_at",
             "DATETIME",
         )
+        _ensure_review_job_quality_telemetry_column(connection)
         _ensure_column(
             connection,
             "comments",
@@ -399,6 +400,22 @@ def _ensure_schema() -> None:
             )
         )
         connection.commit()
+
+
+def _ensure_review_job_quality_telemetry_column(connection) -> None:
+    _ensure_column(
+        connection,
+        "review_jobs",
+        "quality_telemetry",
+        "JSON",
+    )
+    connection.execute(
+        text(
+            "UPDATE review_jobs "
+            "SET quality_telemetry='{}' "
+            "WHERE quality_telemetry IS NULL OR quality_telemetry=''"
+        )
+    )
 
 
 def _ensure_column(connection, table: str, column: str, ddl: str) -> None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -100,6 +100,7 @@ class ReviewJob(Base):
     trigger: Mapped[str] = mapped_column(String(50), default="auto")
     provider: Mapped[str] = mapped_column(String(50), default="openai")
     model: Mapped[str] = mapped_column(String(200), default="gpt-4o-mini")
+    quality_telemetry: Mapped[dict] = mapped_column(JSON, default=dict)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(timezone.utc)

--- a/backend/app/reviews/quality_telemetry.py
+++ b/backend/app/reviews/quality_telemetry.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from app.reviews.parsing import CANONICAL_VIOLATION_TAXONOMY, normalize_comment_output_metadata
+
+
+def build_empty_review_quality_telemetry() -> dict:
+    return {
+        "total_comments": 0,
+        "fallback_count": 0,
+        "truncated_count": 0,
+        "violation_count_by_type": _empty_violation_counts(),
+        "per_persona": {},
+    }
+
+
+def normalize_review_quality_telemetry(telemetry: dict | None) -> dict:
+    normalized = build_empty_review_quality_telemetry()
+    if not isinstance(telemetry, dict):
+        return normalized
+
+    normalized["total_comments"] = _coerce_non_negative_int(telemetry.get("total_comments"))
+    normalized["fallback_count"] = _coerce_non_negative_int(telemetry.get("fallback_count"))
+    normalized["truncated_count"] = _coerce_non_negative_int(telemetry.get("truncated_count"))
+    normalized["violation_count_by_type"] = _normalize_violation_count_map(telemetry.get("violation_count_by_type"))
+
+    raw_per_persona = telemetry.get("per_persona")
+    if isinstance(raw_per_persona, dict):
+        for key, value in raw_per_persona.items():
+            persona_id = _coerce_optional_int(value.get("persona_id") if isinstance(value, dict) else None)
+            if persona_id is None:
+                persona_id = _coerce_optional_int(key)
+            persona_key = str(persona_id) if persona_id is not None else str(key)
+            normalized["per_persona"][persona_key] = _normalize_persona_bucket(value, persona_id)
+
+    return normalized
+
+
+def build_review_quality_telemetry_from_entries(
+    entries: Iterable[tuple[int | None, dict | None, dict | None]],
+) -> dict:
+    telemetry = build_empty_review_quality_telemetry()
+
+    for persona_id, output_metadata, output_requirements in entries:
+        metadata = normalize_comment_output_metadata(output_metadata, output_requirements)
+        _increment_bucket(telemetry, metadata)
+
+        persona_key = str(persona_id) if persona_id is not None else "unknown"
+        bucket = telemetry["per_persona"].setdefault(
+            persona_key,
+            _empty_persona_bucket(persona_id),
+        )
+        _increment_bucket(bucket, metadata)
+
+    return telemetry
+
+
+def _normalize_persona_bucket(value: object, persona_id: int | None) -> dict:
+    if not isinstance(value, dict):
+        value = {}
+    return {
+        "persona_id": persona_id,
+        "total_comments": _coerce_non_negative_int(value.get("total_comments")),
+        "fallback_count": _coerce_non_negative_int(value.get("fallback_count")),
+        "truncated_count": _coerce_non_negative_int(value.get("truncated_count")),
+        "violation_count_by_type": _normalize_violation_count_map(value.get("violation_count_by_type")),
+    }
+
+
+def _empty_violation_counts() -> dict[str, int]:
+    return {name: 0 for name in CANONICAL_VIOLATION_TAXONOMY}
+
+
+def _empty_persona_bucket(persona_id: int | None) -> dict:
+    return {
+        "persona_id": persona_id,
+        "total_comments": 0,
+        "fallback_count": 0,
+        "truncated_count": 0,
+        "violation_count_by_type": _empty_violation_counts(),
+    }
+
+
+def _increment_bucket(bucket: dict, metadata: dict) -> None:
+    bucket["total_comments"] += 1
+    if metadata.get("used_fallback"):
+        bucket["fallback_count"] += 1
+    if metadata.get("truncated"):
+        bucket["truncated_count"] += 1
+
+    counts = bucket["violation_count_by_type"]
+    for violation in metadata.get("violations") or []:
+        if violation not in counts:
+            counts[violation] = 0
+        counts[violation] += 1
+
+
+def _normalize_violation_count_map(value: object) -> dict[str, int]:
+    counts = _empty_violation_counts()
+    if not isinstance(value, dict):
+        return counts
+
+    for key, raw_count in value.items():
+        token = str(key).strip()
+        if not token:
+            continue
+        counts[token] = _coerce_non_negative_int(raw_count)
+    return counts
+
+
+def _coerce_non_negative_int(value: object) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    if parsed < 0:
+        return 0
+    return parsed
+
+
+def _coerce_optional_int(value: object) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -25,6 +25,10 @@ from app.reviews.prompt_builder import (
     build_review_prompt,
     trim_prompt_content,
 )
+from app.reviews.quality_telemetry import (
+    build_review_quality_telemetry_from_entries,
+    normalize_review_quality_telemetry,
+)
 from app.reviews.git_repo import ensure_repo
 from app.reviews.review_storage import write_review_and_commit
 from datetime import datetime, timezone
@@ -45,6 +49,25 @@ def _list_active_personas_for_execution(
         .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
         .order_by(models.Persona.sort_order.asc(), models.Persona.id.asc())
         .all()
+    )
+
+
+def _compute_review_job_quality_telemetry(
+    db: Session,
+    tenant_id: str,
+    review_job_id: int,
+) -> dict:
+    rows = (
+        db.query(models.Comment.persona_id, models.Comment.output_metadata)
+        .filter(
+            models.Comment.tenant_id == tenant_id,
+            models.Comment.review_job_id == review_job_id,
+        )
+        .order_by(models.Comment.id.asc())
+        .all()
+    )
+    return build_review_quality_telemetry_from_entries(
+        (row.persona_id, row.output_metadata, None) for row in rows
     )
 
 
@@ -138,6 +161,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
         persona_specs = build_persona_execution_specs(personas)
 
         results: list[dict] = []
+        telemetry_entries: list[tuple[int | None, dict | None, dict | None]] = []
         max_workers = max(1, min(len(persona_specs), 6))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_map = {}
@@ -160,6 +184,14 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                         comments,
                         version.content,
                     )
+                    for entry in comments:
+                        telemetry_entries.append(
+                            (
+                                spec["id"],
+                                entry.output_metadata,
+                                spec.get("output_requirements"),
+                            )
+                        )
                     results.append(
                         {
                             "persona_id": spec["id"],
@@ -192,6 +224,13 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                         [failure],
                         version.content,
                     )
+                    telemetry_entries.append(
+                        (
+                            spec["id"],
+                            failure.output_metadata,
+                            spec.get("output_requirements"),
+                        )
+                    )
                     results.append(
                         {
                             "persona_id": spec["id"],
@@ -202,6 +241,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                         }
                     )
 
+        job.quality_telemetry = build_review_quality_telemetry_from_entries(telemetry_entries)
         job.status = "completed"
         job.completed_at = datetime.now(timezone.utc)
         db.commit()
@@ -225,6 +265,7 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                     "completed_at": job.completed_at.isoformat() if job.completed_at else None,
                     "provider": job.provider,
                     "model": job.model,
+                    "quality_telemetry": normalize_review_quality_telemetry(job.quality_telemetry),
                     "results": results,
                 }
                 write_review_and_commit(repo, version.id, review_job_id, payload)
@@ -241,6 +282,11 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
                 .first()
             )
             if job:
+                job.quality_telemetry = _compute_review_job_quality_telemetry(
+                    db,
+                    tenant_id,
+                    review_job_id,
+                )
                 job.status = "failed"
                 job.completed_at = datetime.now(timezone.utc)
                 db.commit()
@@ -484,6 +530,13 @@ def retry_failed_persona_in_job(
             comments,
             version.content,
         )
+
+        job.quality_telemetry = _compute_review_job_quality_telemetry(
+            db,
+            tenant_id,
+            review_job_id,
+        )
+        db.commit()
         return len(comments)
     finally:
         db.close()

--- a/backend/app/schemas/review_bundle.py
+++ b/backend/app/schemas/review_bundle.py
@@ -19,6 +19,7 @@ class BundleReviewJob(BaseModel):
     trigger: str = "import"
     provider: str = "import"
     model: str = "bundle"
+    quality_telemetry: dict | None = None
     created_at: datetime | None = None
     completed_at: datetime | None = None
 

--- a/backend/app/schemas/review_job.py
+++ b/backend/app/schemas/review_job.py
@@ -15,6 +15,7 @@ class ReviewJobRead(BaseModel):
     trigger: str
     provider: str
     model: str
+    quality_telemetry: dict = Field(default_factory=dict)
     completed_at: datetime | None
     created_at: datetime
 

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -102,6 +102,7 @@ def test_import_review_bundle_restores_comments_and_meta(client) -> None:
             "trigger": "import",
             "provider": "openai",
             "model": "gpt-4o-mini",
+            "quality_telemetry": {"total_comments": 1},
         },
         "personas": [
             {
@@ -162,6 +163,18 @@ def test_import_review_bundle_restores_comments_and_meta(client) -> None:
     result = import_resp.json()
     assert result["comments_imported"] == 1
     assert result["meta_comments_imported"] == 1
+
+    jobs_resp = client.get(
+        f"/api/review-jobs?document_version_id={result['version_id']}",
+        headers=headers,
+    )
+    assert jobs_resp.status_code == 200
+    jobs = jobs_resp.json()
+    assert len(jobs) == 1
+    telemetry = jobs[0]["quality_telemetry"]
+    assert telemetry["total_comments"] == 1
+    assert telemetry["fallback_count"] == 0
+    assert telemetry["truncated_count"] == 0
 
     library_resp = client.get("/api/documents/library", headers=headers)
     assert library_resp.status_code == 200

--- a/backend/tests/test_init_db_schema.py
+++ b/backend/tests/test_init_db_schema.py
@@ -1,0 +1,55 @@
+from sqlalchemy import create_engine, text
+
+from app.db.init_db import _ensure_review_job_quality_telemetry_column
+
+
+def test_ensure_review_job_quality_telemetry_column_is_backward_safe() -> None:
+    engine = create_engine("sqlite://")
+
+    with engine.connect() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE review_jobs ("
+                "id INTEGER PRIMARY KEY, "
+                "tenant_id TEXT, "
+                "document_version_id INTEGER, "
+                "status TEXT"
+                ")"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO review_jobs (id, tenant_id, document_version_id, status) "
+                "VALUES (1, 'tenant-migrate', 7, 'queued')"
+            )
+        )
+        connection.commit()
+
+        _ensure_review_job_quality_telemetry_column(connection)
+        connection.commit()
+
+        columns = {
+            row[1]
+            for row in connection.execute(text("PRAGMA table_info(review_jobs)")).fetchall()
+        }
+        assert "quality_telemetry" in columns
+
+        first_value = connection.execute(
+            text("SELECT quality_telemetry FROM review_jobs WHERE id=1")
+        ).scalar()
+        assert first_value == "{}"
+
+        preserved_value = '{"total_comments": 5}'
+        connection.execute(
+            text("UPDATE review_jobs SET quality_telemetry=:value WHERE id=1"),
+            {"value": preserved_value},
+        )
+        connection.commit()
+
+        _ensure_review_job_quality_telemetry_column(connection)
+        connection.commit()
+
+        second_value = connection.execute(
+            text("SELECT quality_telemetry FROM review_jobs WHERE id=1")
+        ).scalar()
+        assert second_value == preserved_value

--- a/backend/tests/test_review_worker.py
+++ b/backend/tests/test_review_worker.py
@@ -6,7 +6,15 @@ from uuid import uuid4
 from app.db import models
 from app.db.init_db import seed_default_personas
 from app.db.session import SessionLocal
-from app.reviews.parsing import ParsedComment, normalize_output_requirements
+from app.reviews.parsing import (
+    ParsedComment,
+    VIOLATION_MISSING_ACTIONABLE,
+    VIOLATION_MISSING_QUOTE_EXCERPT,
+    VIOLATION_REVIEW_FAILED,
+    VIOLATION_TRUNCATED_OUTPUT,
+    VIOLATION_UNSTRUCTURED_OUTPUT,
+    normalize_output_requirements,
+)
 from app.reviews.prompt_builder import REQUIRED_PERSONA_EXECUTION_SPEC_FIELDS
 from app.reviews.worker import (
     _auto_trigger_meta_synthesis,
@@ -473,6 +481,117 @@ def test_review_worker_generates_comments_and_auto_triggers_meta(monkeypatch) ->
         assert trigger_calls["document_version_id"] == version.id
         assert trigger_calls["review_job_id"] == job.id
         assert trigger_calls["force"] == 0
+    finally:
+        db.close()
+
+
+def test_review_worker_persists_quality_telemetry_with_per_persona_counts(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-quality-telemetry"
+        monkeypatch.setattr("app.reviews.worker.settings.DOC_REPO_ENABLED", False)
+        monkeypatch.setattr("app.reviews.worker.settings.META_AUTO_SYNTHESIS_ENABLED", False)
+
+        _version, job = _seed_review_context(db, tenant_id)
+        personas = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
+            .order_by(models.Persona.sort_order.asc(), models.Persona.id.asc())
+            .all()
+        )
+        assert len(personas) == 3
+        first_persona_id = personas[0].id
+        second_persona_id = personas[1].id
+
+        def _fake_generate_comments_for_spec(persona, _content):
+            if persona["id"] == first_persona_id:
+                return [
+                    ParsedComment(
+                        text="Needs quote evidence.",
+                        output_metadata={
+                            "used_fallback": True,
+                            "violations": [VIOLATION_MISSING_QUOTE_EXCERPT],
+                        },
+                    )
+                ]
+            if persona["id"] == second_persona_id:
+                return [
+                    ParsedComment(
+                        text="Clarify action scope.",
+                        output_metadata={
+                            "truncated": True,
+                            "violations": [VIOLATION_MISSING_ACTIONABLE],
+                        },
+                    )
+                ]
+            return ["Unstructured summary output"]
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            _fake_generate_comments_for_spec,
+        )
+
+        run_review_job(job.id, tenant_id)
+
+        db.refresh(job)
+        telemetry = job.quality_telemetry
+        assert job.status == "completed"
+        assert telemetry["total_comments"] == 3
+        assert telemetry["fallback_count"] == 2
+        assert telemetry["truncated_count"] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_MISSING_QUOTE_EXCERPT] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_MISSING_ACTIONABLE] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_UNSTRUCTURED_OUTPUT] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_TRUNCATED_OUTPUT] == 1
+        per_persona = telemetry["per_persona"]
+        for persona in personas:
+            assert per_persona[str(persona.id)]["total_comments"] == 1
+    finally:
+        db.close()
+
+
+def test_retry_failed_persona_recomputes_review_job_quality_telemetry(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = "tenant-test-retry-quality-telemetry"
+        monkeypatch.setattr("app.reviews.worker.settings.DOC_REPO_ENABLED", False)
+        monkeypatch.setattr("app.reviews.worker.settings.META_AUTO_SYNTHESIS_ENABLED", False)
+
+        _version, job = _seed_review_context(db, tenant_id)
+        persona = (
+            db.query(models.Persona)
+            .filter(models.Persona.tenant_id == tenant_id, models.Persona.is_active.is_(True))
+            .order_by(models.Persona.id.asc())
+            .first()
+        )
+        assert persona is not None
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            lambda _persona_spec, _content: ["Initial unstructured output"],
+        )
+        run_review_job(job.id, tenant_id)
+
+        db.refresh(job)
+        before_total = job.quality_telemetry["total_comments"]
+        before_persona_total = job.quality_telemetry["per_persona"][str(persona.id)]["total_comments"]
+
+        monkeypatch.setattr(
+            "app.reviews.worker.generate_comments_for_spec",
+            lambda _persona_spec, _content: [
+                ParsedComment(
+                    text='"world" :: clarify wording',
+                    output_metadata={},
+                )
+            ],
+        )
+        added = retry_failed_persona_in_job(job.id, tenant_id, persona.id)
+
+        assert added == 1
+        db.refresh(job)
+        assert job.quality_telemetry["total_comments"] == before_total + 1
+        assert job.quality_telemetry["per_persona"][str(persona.id)]["total_comments"] == before_persona_total + 1
+        assert job.quality_telemetry["violation_count_by_type"][VIOLATION_REVIEW_FAILED] == 0
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- add additive review_jobs.quality_telemetry persistence for review-quality counters (job-level + per-persona)
- persist telemetry atomically with review job completion/failure status transitions in the worker path
- recompute and persist telemetry after persona retry operations to keep job-level totals accurate
- normalize telemetry in review-job read paths for backward compatibility with legacy/partial/null records
- extend bundle import support with optional review-job telemetry payload normalization
- add backward-safe schema init/migration coverage for existing DBs lacking the telemetry column

## Telemetry payload
quality_telemetry includes:
- total_comments
- fallback_count
- truncated_count
- violation_count_by_type
- per_persona buckets (same counters per persona)

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_review_queue.py tests/test_documents.py -> 17 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_init_db_schema.py -> 1 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_comments_and_reviews.py tests/test_review_parsing.py tests/test_parsing.py -> 12 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/reviews/quality_telemetry.py app/reviews/worker.py app/reviews/parsing.py app/db/models.py app/db/init_db.py app/crud/review_job.py app/api/documents.py app/schemas/review_job.py app/schemas/review_bundle.py tests/test_review_worker.py tests/test_documents.py tests/test_init_db_schema.py -> success (no output)

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Review jobs now automatically collect and track quality telemetry metrics throughout execution, including total comments processed, fallback usage counts, output truncation events, and categorized violations by reviewer persona type. Telemetry is normalized and included in all review job API responses for quality monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->