### PR TITLE
feat(api): expose review-quality telemetry in review-job reads (#81)

### DIFF
--- a/backend/app/schemas/review_job.py
+++ b/backend/app/schemas/review_job.py
@@ -1,10 +1,29 @@
 from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
+
+from app.reviews.quality_telemetry import build_empty_review_quality_telemetry
 
 
 class ReviewJobCreate(BaseModel):
     document_version_id: int
     trigger: str | None = None
+
+
+class ReviewJobQualityPersonaRead(BaseModel):
+    persona_id: int | None = None
+    total_comments: int = Field(default=0, ge=0)
+    fallback_count: int = Field(default=0, ge=0)
+    truncated_count: int = Field(default=0, ge=0)
+    violation_count_by_type: dict[str, int] = Field(default_factory=dict)
+
+
+class ReviewJobQualitySummaryRead(BaseModel):
+    total_comments: int = Field(default=0, ge=0)
+    fallback_count: int = Field(default=0, ge=0)
+    truncated_count: int = Field(default=0, ge=0)
+    violation_count_by_type: dict[str, int] = Field(default_factory=dict)
+    per_persona: dict[str, ReviewJobQualityPersonaRead] = Field(default_factory=dict)
 
 
 class ReviewJobRead(BaseModel):
@@ -15,7 +34,9 @@ class ReviewJobRead(BaseModel):
     trigger: str
     provider: str
     model: str
-    quality_telemetry: dict = Field(default_factory=dict)
+    quality_telemetry: ReviewJobQualitySummaryRead = Field(
+        default_factory=lambda: ReviewJobQualitySummaryRead(**build_empty_review_quality_telemetry())
+    )
     completed_at: datetime | None
     created_at: datetime
 

--- a/backend/tests/test_comments_and_reviews.py
+++ b/backend/tests/test_comments_and_reviews.py
@@ -1,4 +1,14 @@
 from app.reviews.parsing import REQUIRED_OUTPUT_METADATA_KEYS, VIOLATION_MISSING_QUOTE_EXCERPT, VIOLATION_TRUNCATED_OUTPUT
+from app.reviews.quality_telemetry import build_empty_review_quality_telemetry
+
+
+def _assert_quality_telemetry_contract(payload: dict) -> None:
+    expected = build_empty_review_quality_telemetry()
+    assert payload["total_comments"] >= 0
+    assert payload["fallback_count"] >= 0
+    assert payload["truncated_count"] >= 0
+    assert set(expected["violation_count_by_type"]).issubset(payload["violation_count_by_type"].keys())
+    assert isinstance(payload["per_persona"], dict)
 
 
 def test_comments_and_review_jobs(client, monkeypatch) -> None:
@@ -41,9 +51,17 @@ def test_comments_and_review_jobs(client, monkeypatch) -> None:
         headers=headers,
     )
     assert job_resp.status_code == 201
-    assert job_resp.json()["status"] == "queued"
-    assert job_resp.json()["provider"] in {"openai", "bedrock"}
-    assert isinstance(job_resp.json()["model"], str)
+    job_data = job_resp.json()
+    assert job_data["status"] == "queued"
+    assert job_data["provider"] in {"openai", "bedrock"}
+    assert isinstance(job_data["model"], str)
+    _assert_quality_telemetry_contract(job_data["quality_telemetry"])
+
+    list_jobs = client.get(f"/api/review-jobs?document_version_id={version_id}", headers=headers)
+    assert list_jobs.status_code == 200
+    jobs = list_jobs.json()
+    assert len(jobs) == 1
+    _assert_quality_telemetry_contract(jobs[0]["quality_telemetry"])
 
     comment_payload = {
         "persona_id": persona_id,

--- a/backend/tests/test_document_permissions.py
+++ b/backend/tests/test_document_permissions.py
@@ -1,3 +1,15 @@
+from app.reviews.quality_telemetry import build_empty_review_quality_telemetry
+
+
+def _assert_quality_telemetry_contract(payload: dict) -> None:
+    expected = build_empty_review_quality_telemetry()
+    assert payload["total_comments"] >= 0
+    assert payload["fallback_count"] >= 0
+    assert payload["truncated_count"] >= 0
+    assert set(expected["violation_count_by_type"]).issubset(payload["violation_count_by_type"].keys())
+    assert isinstance(payload["per_persona"], dict)
+
+
 def test_document_permissions_enforced_for_review_actions(client, monkeypatch) -> None:
     monkeypatch.setattr("app.api.review_jobs.enqueue_review_job", lambda job_id, tenant_id: None)
     tenant = "tenant-perms"
@@ -58,3 +70,109 @@ def test_document_permissions_enforced_for_review_actions(client, monkeypatch) -
         headers=viewer_headers,
     )
     assert can_review.status_code == 201
+    can_review_data = can_review.json()
+    _assert_quality_telemetry_contract(can_review_data["quality_telemetry"])
+
+    hidden_doc = client.post("/api/documents", json={"title": "Admin Only"}, headers=admin_headers)
+    assert hidden_doc.status_code == 201
+    hidden_doc_id = hidden_doc.json()["id"]
+    hidden_version = client.post(
+        f"/api/documents/{hidden_doc_id}/versions",
+        json={"version_label": "v1", "content": "hidden content"},
+        headers=admin_headers,
+    )
+    assert hidden_version.status_code == 201
+    hidden_version_id = hidden_version.json()["id"]
+
+    hidden_job = client.post(
+        "/api/review-jobs",
+        json={"document_version_id": hidden_version_id},
+        headers=admin_headers,
+    )
+    assert hidden_job.status_code == 201
+
+    viewer_jobs = client.get("/api/review-jobs", headers=viewer_headers)
+    assert viewer_jobs.status_code == 200
+    jobs_payload = viewer_jobs.json()
+    assert [job["id"] for job in jobs_payload] == [can_review_data["id"]]
+    for job in jobs_payload:
+        _assert_quality_telemetry_contract(job["quality_telemetry"])
+
+
+def test_review_job_reads_are_tenant_scoped_for_non_admin_users(client, monkeypatch) -> None:
+    monkeypatch.setattr("app.api.review_jobs.enqueue_review_job", lambda job_id, tenant_id: None)
+
+    tenant_a = "tenant-review-scope-a"
+    tenant_b = "tenant-review-scope-b"
+
+    admin_a_headers = {"X-Tenant-Id": tenant_a, "X-User-Email": f"admin+{tenant_a}@local"}
+    admin_b_headers = {"X-Tenant-Id": tenant_b, "X-User-Email": f"admin+{tenant_b}@local"}
+
+    create_viewer = client.post(
+        "/api/admin/users",
+        json={
+            "name": "Scope Viewer",
+            "email": "scope-viewer@example.com",
+            "role": "default",
+            "is_active": True,
+        },
+        headers=admin_a_headers,
+    )
+    assert create_viewer.status_code == 201
+    viewer_id = create_viewer.json()["id"]
+    viewer_headers = {"X-Tenant-Id": tenant_a, "X-User-Email": "scope-viewer@example.com"}
+
+    doc_a = client.post("/api/documents", json={"title": "Tenant A"}, headers=admin_a_headers)
+    assert doc_a.status_code == 201
+    doc_a_id = doc_a.json()["id"]
+    version_a = client.post(
+        f"/api/documents/{doc_a_id}/versions",
+        json={"version_label": "v1", "content": "content a"},
+        headers=admin_a_headers,
+    )
+    assert version_a.status_code == 201
+    version_a_id = version_a.json()["id"]
+
+    grant_viewer = client.post(
+        "/api/admin/permissions",
+        json={"document_id": doc_a_id, "user_id": viewer_id, "permission_level": "viewer"},
+        headers=admin_a_headers,
+    )
+    assert grant_viewer.status_code == 201
+
+    job_a = client.post(
+        "/api/review-jobs",
+        json={"document_version_id": version_a_id},
+        headers=admin_a_headers,
+    )
+    assert job_a.status_code == 201
+    job_a_id = job_a.json()["id"]
+
+    doc_b = client.post("/api/documents", json={"title": "Tenant B"}, headers=admin_b_headers)
+    assert doc_b.status_code == 201
+    doc_b_id = doc_b.json()["id"]
+    version_b = client.post(
+        f"/api/documents/{doc_b_id}/versions",
+        json={"version_label": "v1", "content": "content b"},
+        headers=admin_b_headers,
+    )
+    assert version_b.status_code == 201
+    version_b_id = version_b.json()["id"]
+
+    job_b = client.post(
+        "/api/review-jobs",
+        json={"document_version_id": version_b_id},
+        headers=admin_b_headers,
+    )
+    assert job_b.status_code == 201
+    job_b_id = job_b.json()["id"]
+
+    viewer_jobs = client.get("/api/review-jobs", headers=viewer_headers)
+    assert viewer_jobs.status_code == 200
+    jobs_payload = viewer_jobs.json()
+
+    assert len(jobs_payload) == 1
+    assert jobs_payload[0]["id"] == job_a_id
+    assert jobs_payload[0]["tenant_id"] == tenant_a
+    assert jobs_payload[0]["id"] != job_b_id
+    _assert_quality_telemetry_contract(jobs_payload[0]["quality_telemetry"])


### PR DESCRIPTION
## Summary
- formalize the review-job quality telemetry response as typed API schema models
- keep review-job reads returning quality telemetry for create/list flows with contract-level assertions in integration tests
- add permission and tenant-scope integration coverage for non-admin review-job reads to confirm telemetry remains authorization scoped

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_comments_and_reviews.py tests/test_document_permissions.py tests/test_status.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_documents.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile app/schemas/review_job.py tests/test_comments_and_reviews.py tests/test_document_permissions.py

Closes #81