### PR TITLE
test(qa): add golden persona differentiation fixtures and regression assertions (#82)

### DIFF
--- a/backend/tests/fixtures/persona_golden/persona_bundle_v1.json
+++ b/backend/tests/fixtures/persona_golden/persona_bundle_v1.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "v1",
+  "personas": [
+    {
+      "name": "Clarity Editor",
+      "description": "Improves structure, flow, and readability for technical documents.",
+      "system_prompt": "Act as a rigorous clarity editor. Identify ambiguous or dense passages and recommend concise rewrites that preserve meaning.",
+      "focus_areas": ["structure", "readability", "ambiguity", "flow"],
+      "tone": "direct, constructive",
+      "reference_notes": "Prefer specific rewrite suggestions over abstract critique. Prioritize transitions and sentence-level clarity.",
+      "output_requirements": {
+        "format": "bullet_list",
+        "max_bullets": 4,
+        "require_quote_excerpt": true,
+        "require_actionable": true,
+        "include_severity": false
+      },
+      "examples": [
+        "\"The rollout process is somewhat complicated\" :: Replace with a concrete 3-step rollout sequence."
+      ],
+      "sort_order": 10,
+      "color_theme": "#1d8a7a",
+      "is_active": true,
+      "group_name": "Golden Regression"
+    },
+    {
+      "name": "Risk & Compliance",
+      "description": "Flags security, privacy, legal, and operational risks.",
+      "system_prompt": "Act as a risk and compliance reviewer. Surface security, privacy, legal, and governance risks, then propose concrete mitigations.",
+      "focus_areas": ["security", "privacy", "compliance", "risk", "controls"],
+      "tone": "cautious, precise",
+      "reference_notes": "Escalate policy violations and missing controls. Explicitly call out blast radius and owner accountability.",
+      "output_requirements": {
+        "format": "bullet_list",
+        "max_bullets": 4,
+        "require_quote_excerpt": true,
+        "require_actionable": true,
+        "include_severity": true
+      },
+      "examples": [
+        "[high] \"API keys are stored in plain text\" :: Move keys to managed secrets and rotate within 24 hours."
+      ],
+      "sort_order": 20,
+      "color_theme": "#b7482f",
+      "is_active": true,
+      "group_name": "Golden Regression"
+    },
+    {
+      "name": "Executive Summary",
+      "description": "Synthesizes strategic implications and decision-ready actions.",
+      "system_prompt": "Act as an executive reviewer. Distill strategic implications, unresolved decisions, and ownership gaps for leadership readers.",
+      "focus_areas": ["executive communication", "decision clarity", "ownership", "next steps"],
+      "tone": "succinct, strategic",
+      "reference_notes": "Optimize for boardroom readability. Prefer fewer high-signal bullets with explicit owners and timing.",
+      "output_requirements": {
+        "format": "bullet_list",
+        "max_bullets": 3,
+        "require_quote_excerpt": false,
+        "require_actionable": true,
+        "include_severity": false
+      },
+      "examples": [
+        "Name the unresolved decision, owner, and deadline in one bullet."
+      ],
+      "sort_order": 30,
+      "color_theme": "#2d6eea",
+      "is_active": true,
+      "group_name": "Golden Regression"
+    },
+    {
+      "name": "Nielsen Contrarian",
+      "description": "Challenges weak thinking and generic AI prose with blunt standards.",
+      "system_prompt": "You are a contrarian writing critic inspired by Michael Nielsen's standards for strong technical writing. Reject vague abstractions, demand concrete claims, and call out AI-slop patterns.",
+      "focus_areas": ["argument rigor", "specificity", "novel insight", "anti-slop"],
+      "tone": "blunt, uncompromising",
+      "reference_notes": "If a sentence could appear in any generic AI blog post, flag it. Reward concrete evidence, mechanism, and original reasoning.",
+      "output_requirements": {
+        "format": "bullet_list",
+        "max_bullets": 5,
+        "require_quote_excerpt": true,
+        "require_actionable": true,
+        "include_severity": true
+      },
+      "examples": [
+        "[medium] \"This approach is innovative\" :: Replace with one falsifiable claim and one concrete benchmark."
+      ],
+      "sort_order": 40,
+      "color_theme": "#7a38b5",
+      "is_active": true,
+      "group_name": "Golden Regression"
+    }
+  ]
+}

--- a/backend/tests/fixtures/persona_golden/prompts/clarity_editor.txt
+++ b/backend/tests/fixtures/persona_golden/prompts/clarity_editor.txt
@@ -1,0 +1,31 @@
+You are a document review persona.
+Name: Clarity Editor
+Description: Improves structure, flow, and readability for technical documents.
+System prompt: Act as a rigorous clarity editor. Identify ambiguous or dense passages and recommend concise rewrites that preserve meaning.
+Focus areas: structure, readability, ambiguity, flow
+Tone: direct, constructive
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 4
+- Require quote excerpt: yes
+- Require actionable recommendation: yes
+- Include severity tags: no
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - "<exact excerpt>" :: <actionable comment>
+When quote excerpts are required, use exact document text inside double quotes.
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+Prefer specific rewrite suggestions over abstract critique. Prioritize transitions and sentence-level clarity.
+
+Examples:
+- "The rollout process is somewhat complicated" :: Replace with a concrete 3-step rollout sequence.
+
+Document:
+Project Atlas is rolling out a new policy engine to all regional teams in Q3.
+The current plan says security controls will be improved over time, but it does not define exact milestones.
+Several teams still store API keys in local environment files, and ownership for key rotation is not assigned.
+Leadership expects a concise executive update next week with a go or no-go recommendation.

--- a/backend/tests/fixtures/persona_golden/prompts/executive_summary.txt
+++ b/backend/tests/fixtures/persona_golden/prompts/executive_summary.txt
@@ -1,0 +1,30 @@
+You are a document review persona.
+Name: Executive Summary
+Description: Synthesizes strategic implications and decision-ready actions.
+System prompt: Act as an executive reviewer. Distill strategic implications, unresolved decisions, and ownership gaps for leadership readers.
+Focus areas: executive communication, decision clarity, ownership, next steps
+Tone: succinct, strategic
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 3
+- Require quote excerpt: no
+- Require actionable recommendation: yes
+- Include severity tags: no
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - "<exact excerpt>" :: <actionable comment>
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+Optimize for boardroom readability. Prefer fewer high-signal bullets with explicit owners and timing.
+
+Examples:
+- Name the unresolved decision, owner, and deadline in one bullet.
+
+Document:
+Project Atlas is rolling out a new policy engine to all regional teams in Q3.
+The current plan says security controls will be improved over time, but it does not define exact milestones.
+Several teams still store API keys in local environment files, and ownership for key rotation is not assigned.
+Leadership expects a concise executive update next week with a go or no-go recommendation.

--- a/backend/tests/fixtures/persona_golden/prompts/nielsen_contrarian.txt
+++ b/backend/tests/fixtures/persona_golden/prompts/nielsen_contrarian.txt
@@ -1,0 +1,31 @@
+You are a document review persona.
+Name: Nielsen Contrarian
+Description: Challenges weak thinking and generic AI prose with blunt standards.
+System prompt: You are a contrarian writing critic inspired by Michael Nielsen's standards for strong technical writing. Reject vague abstractions, demand concrete claims, and call out AI-slop patterns.
+Focus areas: argument rigor, specificity, novel insight, anti-slop
+Tone: blunt, uncompromising
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 5
+- Require quote excerpt: yes
+- Require actionable recommendation: yes
+- Include severity tags: yes
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - [high] "<exact excerpt>" :: <actionable comment>
+When quote excerpts are required, use exact document text inside double quotes.
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+If a sentence could appear in any generic AI blog post, flag it. Reward concrete evidence, mechanism, and original reasoning.
+
+Examples:
+- [medium] "This approach is innovative" :: Replace with one falsifiable claim and one concrete benchmark.
+
+Document:
+Project Atlas is rolling out a new policy engine to all regional teams in Q3.
+The current plan says security controls will be improved over time, but it does not define exact milestones.
+Several teams still store API keys in local environment files, and ownership for key rotation is not assigned.
+Leadership expects a concise executive update next week with a go or no-go recommendation.

--- a/backend/tests/fixtures/persona_golden/prompts/risk_and_compliance.txt
+++ b/backend/tests/fixtures/persona_golden/prompts/risk_and_compliance.txt
@@ -1,0 +1,31 @@
+You are a document review persona.
+Name: Risk & Compliance
+Description: Flags security, privacy, legal, and operational risks.
+System prompt: Act as a risk and compliance reviewer. Surface security, privacy, legal, and governance risks, then propose concrete mitigations.
+Focus areas: security, privacy, compliance, risk, controls
+Tone: cautious, precise
+
+Output requirements:
+- Format: bullet_list
+- Max bullets: 4
+- Require quote excerpt: yes
+- Require actionable recommendation: yes
+- Include severity tags: yes
+
+Formatting constraints:
+Use Markdown bullets that start with '- '.
+Example bullet: - [high] "<exact excerpt>" :: <actionable comment>
+When quote excerpts are required, use exact document text inside double quotes.
+When actionable recommendations are required, include a concrete next step.
+
+Reference notes (always consider):
+Escalate policy violations and missing controls. Explicitly call out blast radius and owner accountability.
+
+Examples:
+- [high] "API keys are stored in plain text" :: Move keys to managed secrets and rotate within 24 hours.
+
+Document:
+Project Atlas is rolling out a new policy engine to all regional teams in Q3.
+The current plan says security controls will be improved over time, but it does not define exact milestones.
+Several teams still store API keys in local environment files, and ownership for key rotation is not assigned.
+Leadership expects a concise executive update next week with a go or no-go recommendation.

--- a/backend/tests/fixtures/persona_golden/sample_document.txt
+++ b/backend/tests/fixtures/persona_golden/sample_document.txt
@@ -1,0 +1,4 @@
+Project Atlas is rolling out a new policy engine to all regional teams in Q3.
+The current plan says security controls will be improved over time, but it does not define exact milestones.
+Several teams still store API keys in local environment files, and ownership for key rotation is not assigned.
+Leadership expects a concise executive update next week with a go or no-go recommendation.

--- a/backend/tests/test_persona_portability.py
+++ b/backend/tests/test_persona_portability.py
@@ -1,3 +1,57 @@
+import difflib
+import itertools
+import json
+from difflib import SequenceMatcher
+from pathlib import Path
+
+MAX_NEAR_DUPLICATE_PERSONA_RATIO = 0.9
+
+GOLDEN_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "persona_golden"
+GOLDEN_FIXTURE_PATH = GOLDEN_FIXTURE_DIR / "persona_bundle_v1.json"
+
+
+def _load_golden_bundle() -> dict:
+    return json.loads(GOLDEN_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _persona_signature(persona: dict) -> str:
+    lines = [
+        f"name={persona.get('name', '')}",
+        f"description={persona.get('description', '')}",
+        f"system_prompt={persona.get('system_prompt', '')}",
+        f"focus_areas={','.join(persona.get('focus_areas', []))}",
+        f"tone={persona.get('tone', '')}",
+        f"reference_notes={persona.get('reference_notes', '')}",
+        f"output_requirements={json.dumps(persona.get('output_requirements', {}), sort_keys=True)}",
+        f"examples={json.dumps(persona.get('examples', []), sort_keys=True)}",
+    ]
+    return "\n".join(lines)
+
+
+def _assert_personas_are_differentiated(personas: list[dict]) -> None:
+    for left, right in itertools.combinations(personas, 2):
+        left_sig = _persona_signature(left)
+        right_sig = _persona_signature(right)
+        similarity = SequenceMatcher(None, left_sig, right_sig).ratio()
+        if similarity < MAX_NEAR_DUPLICATE_PERSONA_RATIO:
+            continue
+
+        diff = "".join(
+            difflib.unified_diff(
+                left_sig.splitlines(keepends=True),
+                right_sig.splitlines(keepends=True),
+                fromfile=f"persona/{left.get('name')}",
+                tofile=f"persona/{right.get('name')}",
+                n=2,
+            )
+        )
+        raise AssertionError(
+            "Persona fixture differentiation regression detected: "
+            f"{left.get('name')} vs {right.get('name')} similarity={similarity:.3f} "
+            f">= {MAX_NEAR_DUPLICATE_PERSONA_RATIO}.\nDiff:\n{diff}"
+        )
+
+
 def test_persona_export_and_import_roundtrip(client) -> None:
     headers = {"X-Tenant-Id": "tenant-portable"}
     create_resp = client.post(
@@ -71,3 +125,35 @@ def test_persona_import_dry_run(client) -> None:
     all_resp = client.get("/api/personas", headers=headers)
     assert all_resp.status_code == 200
     assert len(all_resp.json()) == 0
+
+
+def test_golden_persona_fixture_import_export_differentiation(client) -> None:
+    headers = {"X-Tenant-Id": "tenant-portable-golden"}
+    fixture_bundle = _load_golden_bundle()
+    fixture_personas = fixture_bundle["personas"]
+
+    import_resp = client.post(
+        "/api/personas/bundle/import",
+        json={
+            "schema_version": fixture_bundle["schema_version"],
+            "conflict_policy": "skip",
+            "dry_run": False,
+            "personas": fixture_personas,
+        },
+        headers=headers,
+    )
+    assert import_resp.status_code == 200
+    import_body = import_resp.json()
+    assert import_body["created"] == 4
+
+    export_resp = client.get("/api/personas/bundle/export", headers=headers)
+    assert export_resp.status_code == 200
+    exported = export_resp.json()
+    exported_personas = exported["personas"]
+
+    exported_by_name = {item["name"]: item for item in exported_personas}
+    expected_names = [item["name"] for item in fixture_personas]
+    assert set(expected_names).issubset(set(exported_by_name.keys()))
+
+    golden_exported = [exported_by_name[name] for name in expected_names]
+    _assert_personas_are_differentiated(golden_exported)

--- a/backend/tests/test_review_prompt.py
+++ b/backend/tests/test_review_prompt.py
@@ -1,3 +1,7 @@
+import difflib
+import itertools
+import json
+from difflib import SequenceMatcher
 from pathlib import Path
 
 from app.db import models
@@ -10,11 +14,64 @@ from app.reviews.prompt_builder import (
     truncate_prompt_section,
 )
 
-FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "review_prompt"
+REVIEW_PROMPT_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "review_prompt"
+GOLDEN_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "persona_golden"
+GOLDEN_PROMPT_FIXTURE_DIR = GOLDEN_FIXTURE_DIR / "prompts"
+
+EXPECTED_GOLDEN_PERSONA_NAMES = [
+    "Clarity Editor",
+    "Risk & Compliance",
+    "Executive Summary",
+    "Nielsen Contrarian",
+]
+
+GOLDEN_PROMPT_SNAPSHOT_FILES = {
+    "Clarity Editor": "clarity_editor.txt",
+    "Risk & Compliance": "risk_and_compliance.txt",
+    "Executive Summary": "executive_summary.txt",
+    "Nielsen Contrarian": "nielsen_contrarian.txt",
+}
+
+MAX_NEAR_DUPLICATE_PROMPT_RATIO = 0.85
 
 
-def _load_fixture(name: str) -> str:
-    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+def _load_fixture(base_dir: Path, name: str) -> str:
+    return (base_dir / name).read_text(encoding="utf-8")
+
+
+def _load_golden_persona_bundle() -> dict:
+    return json.loads(_load_fixture(GOLDEN_FIXTURE_DIR, "persona_bundle_v1.json"))
+
+
+def _assert_text_fixture(actual: str, *, fixture_path: Path, context: str) -> None:
+    expected = fixture_path.read_text(encoding="utf-8")
+    if actual == expected:
+        return
+
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=f"expected/{fixture_path.name}",
+            tofile=f"actual/{fixture_path.name}",
+            n=2,
+        )
+    )
+    raise AssertionError(f"{context} snapshot mismatch:\n{diff}")
+
+
+def _build_prompt_for_fixture_persona(persona: dict, document_content: str) -> str:
+    return build_review_prompt(
+        name=persona["name"],
+        description=persona.get("description"),
+        system_prompt=persona.get("system_prompt"),
+        focus_areas=persona.get("focus_areas"),
+        tone=persona.get("tone"),
+        content=document_content,
+        reference_notes=persona.get("reference_notes"),
+        output_requirements=persona.get("output_requirements"),
+        examples=persona.get("examples"),
+    )
 
 
 def test_build_review_prompt_handles_none_focus_items() -> None:
@@ -105,7 +162,11 @@ def test_build_review_prompt_contract_snapshot() -> None:
         examples=['[high] "token" :: define expiration behavior'],
     )
 
-    assert prompt == _load_fixture("contract_snapshot.txt")
+    _assert_text_fixture(
+        prompt,
+        fixture_path=REVIEW_PROMPT_FIXTURE_DIR / "contract_snapshot.txt",
+        context="review prompt contract",
+    )
 
 
 def test_build_review_prompt_truncation_snapshot() -> None:
@@ -130,7 +191,63 @@ def test_build_review_prompt_truncation_snapshot() -> None:
         examples_max_total_chars=15,
     )
 
-    assert prompt == _load_fixture("truncation_snapshot.txt")
+    _assert_text_fixture(
+        prompt,
+        fixture_path=REVIEW_PROMPT_FIXTURE_DIR / "truncation_snapshot.txt",
+        context="review prompt truncation",
+    )
+
+
+def test_golden_persona_fixture_contains_representative_personas() -> None:
+    bundle = _load_golden_persona_bundle()
+    names = [persona["name"] for persona in bundle["personas"]]
+    assert names == EXPECTED_GOLDEN_PERSONA_NAMES
+
+
+def test_golden_persona_prompt_snapshots_are_stable() -> None:
+    bundle = _load_golden_persona_bundle()
+    content = _load_fixture(GOLDEN_FIXTURE_DIR, "sample_document.txt").strip()
+
+    for persona in bundle["personas"]:
+        prompt = _build_prompt_for_fixture_persona(persona, content)
+        snapshot_name = GOLDEN_PROMPT_SNAPSHOT_FILES[persona["name"]]
+        _assert_text_fixture(
+            prompt,
+            fixture_path=GOLDEN_PROMPT_FIXTURE_DIR / snapshot_name,
+            context=f"golden persona prompt ({persona['name']})",
+        )
+
+
+def test_golden_persona_prompts_are_differentiated() -> None:
+    bundle = _load_golden_persona_bundle()
+    content = _load_fixture(GOLDEN_FIXTURE_DIR, "sample_document.txt").strip()
+
+    prompts = {
+        persona["name"]: _build_prompt_for_fixture_persona(persona, content)
+        for persona in bundle["personas"]
+    }
+
+    for left_name, right_name in itertools.combinations(prompts.keys(), 2):
+        left_prompt = prompts[left_name]
+        right_prompt = prompts[right_name]
+        similarity = SequenceMatcher(None, left_prompt, right_prompt).ratio()
+        if similarity < MAX_NEAR_DUPLICATE_PROMPT_RATIO:
+            continue
+
+        diff = "".join(
+            difflib.unified_diff(
+                left_prompt.splitlines(keepends=True),
+                right_prompt.splitlines(keepends=True),
+                fromfile=f"prompt/{left_name}",
+                tofile=f"prompt/{right_name}",
+                n=2,
+            )
+        )
+        raise AssertionError(
+            "Golden persona prompts became near-duplicates "
+            f"({left_name} vs {right_name}, similarity={similarity:.3f} >= {MAX_NEAR_DUPLICATE_PROMPT_RATIO}).\n"
+            f"Diff:\n{diff}"
+        )
 
 
 def test_build_persona_execution_spec_includes_all_required_contract_fields() -> None:


### PR DESCRIPTION
## Summary
- add golden persona fixture bundle with representative clarity, risk, executive, and opinionated personas
- add deterministic golden prompt snapshots for the four representative personas against a shared sample document
- add regression assertions to detect near-duplicate persona prompts and provide unified-diff context on failure
- extend persona portability tests to import/export golden fixtures and assert persona differentiation remains intact

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_prompt.py tests/test_review_worker.py tests/test_persona_portability.py
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile tests/test_review_prompt.py tests/test_persona_portability.py

Closes #82