### PR TITLE
test(qa): add failure-mode contract regression suite for timeout/retry/provider failures (#83)

### DIFF
--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.reviews import llm_provider
 
 
@@ -21,3 +23,68 @@ def test_generate_completion_bedrock_dispatch(monkeypatch) -> None:
     monkeypatch.setattr(llm_provider.settings, "LLM_PROVIDER", "bedrock")
     monkeypatch.setattr(llm_provider, "_generate_with_bedrock", lambda prompt: f"ok:{prompt}")
     assert llm_provider.generate_completion("hello") == "ok:hello"
+
+
+def test_generate_completion_unsupported_provider_raises(monkeypatch) -> None:
+    monkeypatch.setattr(llm_provider.settings, "LLM_PROVIDER", "unknown-provider")
+    with pytest.raises(llm_provider.LLMProviderError) as exc:
+        llm_provider.generate_completion("hello")
+    assert "Unsupported LLM provider" in str(exc.value)
+
+
+def test_generate_with_openai_wraps_provider_errors(monkeypatch) -> None:
+    class _DummyOpenAIError(Exception):
+        pass
+
+    class _DummyClient:
+        class responses:
+            @staticmethod
+            def create(**_kwargs):
+                raise _DummyOpenAIError("provider down")
+
+    monkeypatch.setattr(llm_provider, "OpenAIError", _DummyOpenAIError)
+    monkeypatch.setattr(llm_provider, "get_openai_client", lambda: _DummyClient())
+
+    with pytest.raises(llm_provider.LLMProviderError) as exc:
+        llm_provider._generate_with_openai("prompt")
+    assert "provider down" in str(exc.value)
+
+
+def test_generate_with_bedrock_wraps_client_errors(monkeypatch) -> None:
+    class _DummyClient:
+        def converse(self, **_kwargs):
+            raise RuntimeError("bedrock unavailable")
+
+    class _DummySession:
+        def client(self, *_args, **_kwargs):
+            return _DummyClient()
+
+        def get_credentials(self):
+            return object()
+
+    class _DummyBoto3:
+        @staticmethod
+        def Session(**_kwargs):
+            return _DummySession()
+
+    class _DummyBotoConfig:
+        def __init__(self, **_kwargs):
+            pass
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: ANN001
+        if name == "boto3":
+            return _DummyBoto3
+        if name == "botocore.config":
+            return type("_BC", (), {"Config": _DummyBotoConfig})
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(llm_provider.settings, "BEDROCK_MODEL_ID", "model")
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(llm_provider.LLMProviderError) as exc:
+        llm_provider._generate_with_bedrock("prompt")
+    assert "bedrock unavailable" in str(exc.value)

--- a/backend/tests/test_review_worker.py
+++ b/backend/tests/test_review_worker.py
@@ -3,10 +3,13 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
+
 from app.db import models
 from app.db.init_db import seed_default_personas
 from app.db.session import SessionLocal
 from app.reviews.parsing import (
+    REQUIRED_OUTPUT_METADATA_KEYS,
     ParsedComment,
     VIOLATION_MISSING_ACTIONABLE,
     VIOLATION_MISSING_QUOTE_EXCERPT,
@@ -800,8 +803,17 @@ def test_meta_auto_trigger_is_idempotent_for_duplicate_completion_events(monkeyp
         db.close()
 
 
+def _assert_review_failed_metadata_contract(output_metadata: dict, output_requirements: dict | None) -> None:
+    assert set(REQUIRED_OUTPUT_METADATA_KEYS).issubset(output_metadata.keys())
+    assert output_metadata["requirements"] == normalize_output_requirements(output_requirements)
+    assert output_metadata["violations"] == [VIOLATION_REVIEW_FAILED]
+    assert output_metadata["used_fallback"] is True
+    assert output_metadata["truncated"] is False
+
+
 def test_generate_with_timeout_retry_retries_on_timeout(monkeypatch) -> None:
     calls = {"count": 0}
+    sleep_calls: list[int] = []
 
     def _fake_generate(_prompt: str) -> str:
         calls["count"] += 1
@@ -810,7 +822,142 @@ def test_generate_with_timeout_retry_retries_on_timeout(monkeypatch) -> None:
         return "- \"a\" :: ok"
 
     monkeypatch.setattr("app.reviews.worker.generate_completion", _fake_generate)
-    monkeypatch.setattr("app.reviews.worker.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("app.reviews.worker.time.sleep", lambda seconds: sleep_calls.append(seconds))
     output = _generate_with_timeout_retry("prompt")
     assert output == '- "a" :: ok'
     assert calls["count"] == 3
+    assert sleep_calls == [1, 2]
+
+
+def test_generate_with_timeout_retry_raises_after_max_attempts_with_backoff(monkeypatch) -> None:
+    calls = {"count": 0}
+    sleep_calls: list[int] = []
+
+    def _always_timeout(_prompt: str) -> str:
+        calls["count"] += 1
+        raise TimeoutError("request timed out")
+
+    monkeypatch.setattr("app.reviews.worker.generate_completion", _always_timeout)
+    monkeypatch.setattr("app.reviews.worker.time.sleep", lambda seconds: sleep_calls.append(seconds))
+
+    with pytest.raises(TimeoutError, match="timed out after 3 attempts"):
+        _generate_with_timeout_retry("prompt")
+
+    assert calls["count"] == 3
+    assert sleep_calls == [1, 2]
+
+
+def test_generate_with_timeout_retry_does_not_retry_non_timeout_provider_error(monkeypatch) -> None:
+    calls = {"count": 0}
+    sleep_calls: list[int] = []
+
+    def _provider_failure(_prompt: str) -> str:
+        calls["count"] += 1
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr("app.reviews.worker.generate_completion", _provider_failure)
+    monkeypatch.setattr("app.reviews.worker.time.sleep", lambda seconds: sleep_calls.append(seconds))
+
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        _generate_with_timeout_retry("prompt")
+
+    assert calls["count"] == 1
+    assert sleep_calls == []
+
+
+def test_run_review_job_timeout_path_persists_deterministic_fallback_comment(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = f"tenant-test-timeout-fallback-{uuid4().hex}"
+        monkeypatch.setattr("app.reviews.worker.settings.DOC_REPO_ENABLED", False)
+        monkeypatch.setattr("app.reviews.worker.settings.META_AUTO_SYNTHESIS_ENABLED", False)
+
+        _version, job = _seed_review_context_without_personas(db, tenant_id)
+        persona = _create_persona(db, tenant_id, name="Timeout Persona", sort_order=10)
+
+        calls = {"count": 0}
+        sleep_calls: list[int] = []
+
+        def _always_timeout(_prompt: str) -> str:
+            calls["count"] += 1
+            raise TimeoutError("request timed out")
+
+        monkeypatch.setattr("app.reviews.worker.generate_completion", _always_timeout)
+        monkeypatch.setattr("app.reviews.worker.time.sleep", lambda seconds: sleep_calls.append(seconds))
+
+        run_review_job(job.id, tenant_id)
+
+        db.refresh(job)
+        assert job.status == "completed"
+
+        comments = (
+            db.query(models.Comment)
+            .filter(
+                models.Comment.tenant_id == tenant_id,
+                models.Comment.review_job_id == job.id,
+                models.Comment.persona_id == persona.id,
+            )
+            .all()
+        )
+        assert len(comments) == 1
+        assert comments[0].text.startswith("Review failed: ")
+        _assert_review_failed_metadata_contract(comments[0].output_metadata, persona.output_requirements)
+
+        assert calls["count"] == 3
+        assert sleep_calls == [1, 2]
+
+        telemetry = job.quality_telemetry
+        assert telemetry["total_comments"] == 1
+        assert telemetry["fallback_count"] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_REVIEW_FAILED] == 1
+    finally:
+        db.close()
+
+
+def test_run_review_job_provider_failure_path_persists_deterministic_fallback_comment(monkeypatch) -> None:
+    db = SessionLocal()
+    try:
+        tenant_id = f"tenant-test-provider-fallback-{uuid4().hex}"
+        monkeypatch.setattr("app.reviews.worker.settings.DOC_REPO_ENABLED", False)
+        monkeypatch.setattr("app.reviews.worker.settings.META_AUTO_SYNTHESIS_ENABLED", False)
+
+        _version, job = _seed_review_context_without_personas(db, tenant_id)
+        persona = _create_persona(db, tenant_id, name="Provider Failure Persona", sort_order=10)
+
+        calls = {"count": 0}
+        sleep_calls: list[int] = []
+
+        def _provider_failure(_prompt: str) -> str:
+            calls["count"] += 1
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr("app.reviews.worker.generate_completion", _provider_failure)
+        monkeypatch.setattr("app.reviews.worker.time.sleep", lambda seconds: sleep_calls.append(seconds))
+
+        run_review_job(job.id, tenant_id)
+
+        db.refresh(job)
+        assert job.status == "completed"
+
+        comments = (
+            db.query(models.Comment)
+            .filter(
+                models.Comment.tenant_id == tenant_id,
+                models.Comment.review_job_id == job.id,
+                models.Comment.persona_id == persona.id,
+            )
+            .all()
+        )
+        assert len(comments) == 1
+        assert comments[0].text.startswith("Review failed: provider unavailable")
+        _assert_review_failed_metadata_contract(comments[0].output_metadata, persona.output_requirements)
+
+        assert calls["count"] == 1
+        assert sleep_calls == []
+
+        telemetry = job.quality_telemetry
+        assert telemetry["total_comments"] == 1
+        assert telemetry["fallback_count"] == 1
+        assert telemetry["violation_count_by_type"][VIOLATION_REVIEW_FAILED] == 1
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add deterministic regression coverage for timeout and provider-failure execution paths in review worker
- verify fallback comment contract markers (violations, used_fallback, truncated, requirements) remain explicit under degraded behavior
- expand timeout retry assertions to cover max-attempt exhaustion and backoff schedule enforcement
- add LLM provider regression tests for unsupported provider and wrapped provider exception behavior

## Validation
- cd /home/zob/src/OpinionatedDocReviewer/backend && .venv/bin/pytest tests/test_review_worker.py tests/test_llm_provider.py tests/test_review_queue.py -> 24 passed
- cd /home/zob/src/OpinionatedDocReviewer/backend && python3 -m py_compile tests/test_review_worker.py tests/test_llm_provider.py -> success (no output)

Closes #83