### PR TITLE
feat(ci): add dedicated track-1 contract regression gate and contributor docs (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
-      - name: Run backend tests (includes OpenAI/Bedrock provider smoke tests)
+      - name: Install backend deps
         run: |
           cd backend
           uv sync --extra test
+      - name: Run Track-1 review-contract regression tests (M2 gate)
+        run: |
+          cd backend
+          uv run pytest tests/test_review_prompt.py tests/test_review_parsing.py tests/test_review_worker.py tests/test_personas.py
+      - name: Run backend tests (includes OpenAI/Bedrock provider smoke tests)
+        run: |
+          cd backend
           uv run pytest
 
   frontend:

--- a/docs/process/github-branch-protection-audit.md
+++ b/docs/process/github-branch-protection-audit.md
@@ -105,3 +105,15 @@ gh api repos/jonzobrist/OpinionatedDocReviewer/branches/main/protection --jq '{r
 ### Operational note
 - CODEOWNERS placeholder handles were replaced with `@jonzobrist` to make CODEOWNER review enforcement effective immediately.
 - Follow-up: split ownership by area/team once long-term maintainers are confirmed.
+
+## Update: Track-1 review-contract CI gate added (2026-03-05 01:43 UTC)
+
+### Change summary
+- Added explicit CI segment in `/home/zob/src/OpinionatedDocReviewer/.github/workflows/ci.yml` under job/context `backend`:
+  - Step name: `Run Track-1 review-contract regression tests (M2 gate)`
+  - Command scope: `tests/test_review_prompt.py`, `tests/test_review_parsing.py`, `tests/test_review_worker.py`, `tests/test_personas.py`
+- Branch-protection required status-check contexts are **unchanged**:
+  - `backend`, `frontend`, `dependency-review`, `backend-audit`, `frontend-audit`
+
+### Policy fit
+- The Track-1 gate is enforced inside the required `backend` context, so existing branch protection remains compatible while adding stricter M2 quality coverage.

--- a/docs/process/github-free-workflow.md
+++ b/docs/process/github-free-workflow.md
@@ -178,8 +178,15 @@ If branch protection/rulesets are available for this repository type:
 - Require PR before merge
 - Require at least 1 approval
 - Require conversation resolution
-- Require status checks: `CI / backend`, `CI / frontend`, `Security Scan / backend-audit`, `Security Scan / frontend-audit`
+- Require status-check contexts: `backend`, `frontend`, `dependency-review`, `backend-audit`, `frontend-audit`
 - Restrict force-push/deletions on `main`
+
+Mapping note (workflow display -> enforceable context):
+- `CI / backend` -> `backend`
+- `CI / frontend` -> `frontend`
+- `Security Scan / dependency-review` -> `dependency-review`
+- `Security Scan / backend-audit` -> `backend-audit`
+- `Security Scan / frontend-audit` -> `frontend-audit`
 
 If not available in your specific free-tier context:
 - Enforce socially: no direct pushes to `main`
@@ -225,6 +232,24 @@ Noise controls:
 - Easy rollback: disable/delete workflow file.
 
 None of the above require paid GitHub plans.
+
+### M2 Track-1 review-contract quality gate (Issue #84)
+
+This repository now enforces an explicit Track-1 regression segment in CI under the required `backend` context:
+- Workflow: `/home/zob/src/OpinionatedDocReviewer/.github/workflows/ci.yml`
+- Step: `Run Track-1 review-contract regression tests (M2 gate)`
+- Command:
+  ```bash
+  cd /home/zob/src/OpinionatedDocReviewer/backend && uv sync --extra test && uv run pytest tests/test_review_prompt.py tests/test_review_parsing.py tests/test_review_worker.py tests/test_personas.py
+  ```
+
+Contributor expectation for PRs touching the review engine (`/home/zob/src/OpinionatedDocReviewer/backend/app/reviews/**` and related parser/prompt tests):
+- Run the Track-1 command above locally before opening PR.
+- Include command output in PR evidence section.
+
+Branch-protection compatibility note:
+- Required contexts remain `backend`, `frontend`, `dependency-review`, `backend-audit`, `frontend-audit`.
+- See `/home/zob/src/OpinionatedDocReviewer/docs/process/github-branch-protection-audit.md` for audit evidence.
 
 ---
 


### PR DESCRIPTION
## Summary
- add an explicit Track-1 review-contract regression segment to the CI backend job
- document contributor expectations and required local Track-1 contract command for review-engine PRs
- update branch-protection audit notes to show this gate remains compatible with enforced required contexts

## Acceptance Criteria Mapping
1) CI includes a dedicated review-contract test segment
- Added step `Run Track-1 review-contract regression tests (M2 gate)` in `/home/zob/src/OpinionatedDocReviewer/.github/workflows/ci.yml`

2) Contributor docs define required M2 contract tests for PRs touching review engine
- Updated `/home/zob/src/OpinionatedDocReviewer/docs/process/github-free-workflow.md` with a dedicated M2 Track-1 quality gate section and command expectations

3) Required-check policy for M2 validated against branch protection process
- Updated `/home/zob/src/OpinionatedDocReviewer/docs/process/github-branch-protection-audit.md` with policy-fit note and explicit statement that required contexts remain unchanged

## Validation
```bash
cd /tmp/odr-m2-84/backend
PATH="/tmp/odr-m2-84/.venv-ci-check/bin:$PATH" uv sync --extra test
PATH="/tmp/odr-m2-84/.venv-ci-check/bin:$PATH" uv run pytest tests/test_review_prompt.py tests/test_review_parsing.py tests/test_review_worker.py tests/test_personas.py
# result: 37 passed

cd /tmp/odr-m2-84/frontend
PATH="$HOME/.bun/bin:$PATH" bun install --frozen-lockfile
PATH="$HOME/.bun/bin:$PATH" bun run build
# result: build successful

gh api repos/jonzobrist/OpinionatedDocReviewer/branches/main/protection --jq '.required_status_checks.contexts'
# result: ["backend","backend-audit","dependency-review","frontend","frontend-audit"]
```

## Required-check policy notes
- Required branch-protection contexts remain: `backend`, `frontend`, `dependency-review`, `backend-audit`, `frontend-audit`
- The Track-1 gate is intentionally implemented as a dedicated step inside the `backend` job/context to avoid breaking required-check compatibility

## Risk notes
- Low risk: CI runtime will increase slightly because the Track-1 subset is run explicitly before full backend suite
- No runtime/app behavior changes (CI + docs only)

Closes #84
