### PR TITLE
fix(frontend): update URL immediately after upload for shareable doc links (#46)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1147,6 +1147,14 @@ function HomePageContent() {
     }
   }
 
+  function navigateToDocumentContext(documentId: number) {
+    const nextParams = new URLSearchParams(latestSearchParamsKeyRef.current);
+    nextParams.set('doc', String(documentId));
+    nextParams.delete('run');
+    const nextQuery = nextParams.toString();
+    router.replace(nextQuery ? `/?${nextQuery}` : '/');
+  }
+
   async function handleUploadFiles(files: FileList | File[]) {
     if (!files || files.length === 0) return;
     setIsUploading(true);
@@ -1199,6 +1207,7 @@ function HomePageContent() {
     }
     if (lastDocId) {
       setSelectedDocumentId(lastDocId);
+      navigateToDocumentContext(lastDocId);
       await loadVersions(lastDocId);
     }
     if (lastVersionId) {
@@ -2767,6 +2776,7 @@ function HomePageContent() {
     setErrorMessage(null);
     try {
       let importedCount = 0;
+      let lastImportedDocumentId: number | null = null;
       for (const file of list) {
         const filename = file.name.toLowerCase();
         let payload: unknown = null;
@@ -2820,8 +2830,12 @@ function HomePageContent() {
           body: JSON.stringify(payload)
         });
         importedCount += 1;
+        lastImportedDocumentId = result.document_id;
         setSelectedDocumentId(result.document_id);
         await loadVersions(result.document_id);
+      }
+      if (lastImportedDocumentId) {
+        navigateToDocumentContext(lastImportedDocumentId);
       }
       await refreshAll();
       setStatusMessage(`Imported ${importedCount} review bundle${importedCount === 1 ? '' : 's'}.`);

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -123,6 +123,20 @@ describe('page controls', () => {
         return json({ created: 1, updated: 0, renamed: 0, skipped: 0, errors: [] });
       }
       if (url.endsWith('/documents/library')) return json(documentLibraryPayload);
+      if (url.endsWith('/documents') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body || '{}'));
+        return json(
+          {
+            id: 303,
+            tenant_id: 'local-dev',
+            title: body.title ?? 'Uploaded Doc',
+            is_archived: false,
+            archived_at: null,
+            created_at: new Date().toISOString()
+          },
+          201
+        );
+      }
       if (url.endsWith('/documents')) return json([]);
       if (url.endsWith('/documents/101/history')) {
         return json([
@@ -134,6 +148,23 @@ describe('page controls', () => {
         ]);
       }
       if (url.includes('/review-jobs') && (!init?.method || init.method === 'GET')) {
+        const parsed = new URL(url, 'http://localhost');
+        const versionId = Number(parsed.searchParams.get('document_version_id') ?? '0');
+        if (versionId === 703) {
+          return json([
+            {
+              id: 888,
+              tenant_id: 'local-dev',
+              document_version_id: 703,
+              status: 'completed',
+              trigger: 'upload',
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+              completed_at: new Date().toISOString(),
+              created_at: new Date().toISOString()
+            }
+          ]);
+        }
         return json([
           {
             id: 501,
@@ -149,13 +180,15 @@ describe('page controls', () => {
         ]);
       }
       if (url.endsWith('/review-jobs') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body || '{}'));
+        const versionId = Number(body.document_version_id ?? 401);
         return json(
           {
-            id: 777,
+            id: versionId === 703 ? 888 : 777,
             tenant_id: 'local-dev',
-            document_version_id: 401,
+            document_version_id: versionId,
             status: 'queued',
-            trigger: 'manual',
+            trigger: body.trigger ?? 'manual',
             provider: 'openai',
             model: 'gpt-4o-mini',
             completed_at: null,
@@ -176,6 +209,31 @@ describe('page controls', () => {
           }
         ]);
       }
+      if (url.endsWith('/documents/303/versions') && init?.method === 'POST') {
+        return json(
+          {
+            id: 703,
+            tenant_id: 'local-dev',
+            document_id: 303,
+            version_label: 'Initial upload',
+            content: '# Uploaded',
+            created_at: new Date().toISOString()
+          },
+          201
+        );
+      }
+      if (url.endsWith('/documents/303/versions')) {
+        return json([
+          {
+            id: 703,
+            tenant_id: 'local-dev',
+            document_id: 303,
+            version_label: 'Initial upload',
+            content: '# Uploaded',
+            created_at: new Date().toISOString()
+          }
+        ]);
+      }
       if (url.endsWith('/documents/202/versions')) {
         return json([
           {
@@ -189,6 +247,9 @@ describe('page controls', () => {
         ]);
       }
       if (url.includes('/comments?document_version_id=401&review_job_id=501')) {
+        return json([]);
+      }
+      if (url.includes('/comments?document_version_id=703')) {
         return json([]);
       }
       if (url.includes('/comments?document_version_id=401') && !url.includes('review_job_id=')) {
@@ -925,6 +986,47 @@ describe('page controls', () => {
     ).toBe(true);
   });
 
+  it('updates URL immediately after upload and restores uploaded context from URL', async () => {
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams();
+    render(<HomePage />);
+
+    const uploadInput = document.querySelector(
+      'input[type="file"][accept=".md,.markdown,.txt,text/markdown,text/plain"]'
+    );
+    expect(uploadInput).toBeTruthy();
+
+    replaceMock.mockClear();
+    const uploadFile = {
+      name: 'uploaded.md',
+      text: async () => '# Uploaded\n\nBody'
+    };
+    fireEvent.change(uploadInput as HTMLInputElement, { target: { files: [uploadFile] } });
+
+    await waitFor(() => {
+      const urls = replaceMock.mock.calls.map((call) => String(call[0]));
+      expect(urls.some((url) => url.includes('doc=303'))).toBe(true);
+    });
+
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockClear();
+    cleanup();
+
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=303');
+    render(<HomePage />);
+
+    expect(
+      await screen.findByText('No meta directives found for this run yet. Showing individual reviewer comments.')
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((args) =>
+        String(args[0])
+      );
+      expect(calls.some((url) => url.includes('/documents/303/versions'))).toBe(true);
+    });
+  });
+
   it('saves system settings to localStorage', async () => {
     mockPathname = '/system';
     render(<HomePage />);
@@ -1000,7 +1102,7 @@ describe('page controls', () => {
     expect(await screen.findByText(/Import complete:/i)).toBeTruthy();
   });
 
-  it('imports review bundle from library', async () => {
+  it('imports review bundle from library and updates URL to imported document context', async () => {
     mockPathname = '/library';
     render(<HomePage />);
 
@@ -1025,8 +1127,13 @@ describe('page controls', () => {
           ]
         })
     };
+    replaceMock.mockClear();
     fireEvent.change(importInput as HTMLInputElement, { target: { files: [bundle] } });
 
     await screen.findByText(/Imported 1 review bundle/i);
+    await waitFor(() => {
+      const urls = replaceMock.mock.calls.map((call) => String(call[0]));
+      expect(urls.some((url) => url.includes('doc=202'))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- update upload success flow to immediately write document context into the URL (`/?doc=<id>`) via `router.replace`
- apply the same immediate URL update for review bundle import success so imported docs are shareable without extra Library navigation
- keep existing mode/selection behavior intact while only adding document-context URL sync on upload/import success

## Before vs After URL behavior (evidence)
- **Before:** Upload/import could complete while URL remained `/` or `/library`, so copied links did not preserve the new document context.
- **After:** Successful upload/import updates URL to include `doc` immediately (e.g. `/?doc=303`, `/?doc=202`).

Test evidence added:
- `updates URL immediately after upload and restores uploaded context from URL`
  - asserts immediate URL update with `doc=303`
  - rerenders with `doc=303` and verifies document context is loaded from URL
- `imports review bundle from library and updates URL to imported document context`
  - asserts URL update with `doc=202` on import success

## Validation
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && NODE_ENV=test pnpm vitest run tests/pageControls.test.tsx tests/uploadFlow.test.ts`
  - passed (2 files, 24 tests)
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && pnpm run build`
  - passed (Next.js production build succeeded)

Closes #46
