### PR TITLE
feat(review-jobs): add review-generation metadata foundation for #50

### DIFF
--- a/backend/app/crud/review_job.py
+++ b/backend/app/crud/review_job.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db import models
@@ -7,6 +10,53 @@ from app.reviews.quality_telemetry import (
     normalize_review_quality_telemetry,
 )
 from app.schemas.review_job import ReviewJobCreate
+
+
+def _attach_generation_metadata(
+    db: Session,
+    tenant_id: str,
+    jobs: list[models.ReviewJob],
+) -> None:
+    if not jobs:
+        return
+
+    version_ids = sorted({job.document_version_id for job in jobs})
+    generation_index_by_job_id: dict[int, int] = {}
+    latest_job_id_by_version: dict[int, int] = {}
+    running_index_by_version: dict[int, int] = defaultdict(int)
+
+    version_rows = (
+        db.query(models.ReviewJob.id, models.ReviewJob.document_version_id)
+        .filter(
+            models.ReviewJob.tenant_id == tenant_id,
+            models.ReviewJob.document_version_id.in_(version_ids),
+        )
+        .order_by(models.ReviewJob.document_version_id.asc(), models.ReviewJob.id.asc())
+        .all()
+    )
+    for review_job_id, document_version_id in version_rows:
+        running_index_by_version[document_version_id] += 1
+        generation_index_by_job_id[review_job_id] = running_index_by_version[document_version_id]
+        latest_job_id_by_version[document_version_id] = review_job_id
+
+    job_ids = [job.id for job in jobs]
+    comment_count_rows = (
+        db.query(models.Comment.review_job_id, func.count(models.Comment.id))
+        .filter(
+            models.Comment.tenant_id == tenant_id,
+            models.Comment.review_job_id.is_not(None),
+            models.Comment.review_job_id.in_(job_ids),
+        )
+        .group_by(models.Comment.review_job_id)
+        .all()
+    )
+    comment_count_by_job_id = {review_job_id: int(count) for review_job_id, count in comment_count_rows}
+
+    for job in jobs:
+        job.generation_index = generation_index_by_job_id.get(job.id)
+        latest_for_version = latest_job_id_by_version.get(job.document_version_id)
+        job.is_latest_for_version = latest_for_version == job.id if latest_for_version is not None else None
+        job.comment_count = comment_count_by_job_id.get(job.id, 0)
 
 
 def create_job(db: Session, tenant_id: str, data: ReviewJobCreate) -> models.ReviewJob:
@@ -22,6 +72,8 @@ def create_job(db: Session, tenant_id: str, data: ReviewJobCreate) -> models.Rev
     db.add(job)
     db.commit()
     db.refresh(job)
+    _attach_generation_metadata(db, tenant_id, [job])
+    job.quality_telemetry = normalize_review_quality_telemetry(job.quality_telemetry)
     return job
 
 
@@ -32,6 +84,7 @@ def list_jobs(
     if document_version_id is not None:
         query = query.filter(models.ReviewJob.document_version_id == document_version_id)
     jobs = query.order_by(models.ReviewJob.id.asc()).all()
+    _attach_generation_metadata(db, tenant_id, jobs)
     for job in jobs:
         job.quality_telemetry = normalize_review_quality_telemetry(job.quality_telemetry)
     return jobs
@@ -50,5 +103,6 @@ def get_latest_job_for_version(
         .first()
     )
     if job is not None:
+        _attach_generation_metadata(db, tenant_id, [job])
         job.quality_telemetry = normalize_review_quality_telemetry(job.quality_telemetry)
     return job

--- a/backend/app/schemas/review_job.py
+++ b/backend/app/schemas/review_job.py
@@ -34,6 +34,9 @@ class ReviewJobRead(BaseModel):
     trigger: str
     provider: str
     model: str
+    generation_index: int | None = Field(default=None, ge=1)
+    is_latest_for_version: bool | None = None
+    comment_count: int = Field(default=0, ge=0)
     quality_telemetry: ReviewJobQualitySummaryRead = Field(
         default_factory=lambda: ReviewJobQualitySummaryRead(**build_empty_review_quality_telemetry())
     )

--- a/backend/tests/test_comments_and_reviews.py
+++ b/backend/tests/test_comments_and_reviews.py
@@ -55,17 +55,24 @@ def test_comments_and_review_jobs(client, monkeypatch) -> None:
     assert job_data["status"] == "queued"
     assert job_data["provider"] in {"openai", "bedrock"}
     assert isinstance(job_data["model"], str)
+    assert job_data["generation_index"] == 1
+    assert job_data["is_latest_for_version"] is True
+    assert job_data["comment_count"] == 0
     _assert_quality_telemetry_contract(job_data["quality_telemetry"])
 
     list_jobs = client.get(f"/api/review-jobs?document_version_id={version_id}", headers=headers)
     assert list_jobs.status_code == 200
     jobs = list_jobs.json()
     assert len(jobs) == 1
+    assert jobs[0]["generation_index"] == 1
+    assert jobs[0]["is_latest_for_version"] is True
+    assert jobs[0]["comment_count"] == 0
     _assert_quality_telemetry_contract(jobs[0]["quality_telemetry"])
 
     comment_payload = {
         "persona_id": persona_id,
         "document_version_id": version_id,
+        "review_job_id": job_data["id"],
         "text": "Consider adding more details.",
         "start_offset": 0,
         "end_offset": 5,
@@ -79,6 +86,45 @@ def test_comments_and_review_jobs(client, monkeypatch) -> None:
     )
     assert list_comments.status_code == 200
     assert len(list_comments.json()) == 1
+
+    list_jobs_after_comment = client.get(
+        f"/api/review-jobs?document_version_id={version_id}", headers=headers
+    )
+    assert list_jobs_after_comment.status_code == 200
+    jobs_after_comment = list_jobs_after_comment.json()
+    assert len(jobs_after_comment) == 1
+    assert jobs_after_comment[0]["generation_index"] == 1
+    assert jobs_after_comment[0]["is_latest_for_version"] is True
+    assert jobs_after_comment[0]["comment_count"] == 1
+
+    second_job_resp = client.post(
+        "/api/review-jobs",
+        json={"document_version_id": version_id, "trigger": "manual"},
+        headers=headers,
+    )
+    assert second_job_resp.status_code == 201
+    second_job_data = second_job_resp.json()
+    assert second_job_data["generation_index"] == 2
+    assert second_job_data["is_latest_for_version"] is True
+    assert second_job_data["comment_count"] == 0
+
+    list_jobs_two_runs = client.get(
+        f"/api/review-jobs?document_version_id={version_id}", headers=headers
+    )
+    assert list_jobs_two_runs.status_code == 200
+    jobs_two_runs = list_jobs_two_runs.json()
+    assert len(jobs_two_runs) == 2
+
+    first, second = jobs_two_runs
+    assert first["id"] == job_data["id"]
+    assert first["generation_index"] == 1
+    assert first["is_latest_for_version"] is False
+    assert first["comment_count"] == 1
+
+    assert second["id"] == second_job_data["id"]
+    assert second["generation_index"] == 2
+    assert second["is_latest_for_version"] is True
+    assert second["comment_count"] == 0
 
 
 def test_comments_endpoint_normalizes_legacy_output_metadata(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add additive review-generation metadata to `ReviewJobRead` for generation browsing UX
  - `generation_index`
  - `is_latest_for_version`
  - `comment_count`
- hydrate generation metadata in review-job CRUD paths
- extend API tests to verify generation ordering/latest marker/comment counts across multiple runs

## Why
Issue #50 needs generation browsing without a large redesign. Backend already stores runs/comments by `review_job_id`; this PR exposes lightweight metadata to support a clean generation selector in follow-up frontend work.

## Scope
- Backend only (no frontend/runtime behavior changes in this PR)
- Additive API contract fields (backward compatible)

## Validation
```bash
cd /tmp/odr-50-backend/backend
python -m venv .venv
. .venv/bin/activate
pip install -e .[test]
python -m pytest tests/test_comments_and_reviews.py tests/test_review_worker.py
# result: 20 passed
```

## Follow-up (separate PR after #46 merge)
- add primary-pane generation selector in `frontend/app/page.tsx`
- wire selector to `selectedReviewJobId` for comment/meta reload

Refs #50
