### PR TITLE
feat(frontend): add review generation selector and scoped comment browsing (#50)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -268,9 +268,57 @@ function HomePageContent() {
     () => versions.find((version) => version.id === selectedVersionId) ?? null,
     [versions, selectedVersionId]
   );
+  const reviewGenerationOptions = useMemo(() => {
+    if (reviewJobs.length === 0) return [];
+
+    const jobsById = [...reviewJobs].sort((a, b) => a.id - b.id);
+    const generationByJobId = new Map<number, number>();
+    let fallbackGeneration = 0;
+
+    for (const job of jobsById) {
+      const generationFromApi = normalizeGenerationIndex(job.generation_index);
+      if (generationFromApi !== null) {
+        fallbackGeneration = Math.max(fallbackGeneration, generationFromApi);
+        generationByJobId.set(job.id, generationFromApi);
+      } else {
+        fallbackGeneration += 1;
+        generationByJobId.set(job.id, fallbackGeneration);
+      }
+    }
+
+    const latestGeneration = jobsById.reduce((latest, job) => {
+      return Math.max(latest, generationByJobId.get(job.id) ?? 0);
+    }, 0);
+
+    return reviewJobs
+      .map((job) => {
+        const generation = generationByJobId.get(job.id) ?? 1;
+        const isLatest =
+          typeof job.is_latest_for_version === 'boolean'
+            ? job.is_latest_for_version
+            : generation === latestGeneration;
+        const commentCount = Number.isInteger(job.comment_count) ? Number(job.comment_count) : null;
+        const commentLabel =
+          commentCount === null
+            ? ''
+            : ` · ${commentCount} comment${commentCount === 1 ? '' : 's'}`;
+        return {
+          job,
+          generation,
+          isLatest,
+          label: `v${generation}${isLatest ? ' (latest)' : ''} · run #${job.id} · ${job.status}${commentLabel}`
+        };
+      })
+      .sort((a, b) => b.generation - a.generation || b.job.id - a.job.id);
+  }, [reviewJobs]);
+
   const selectedReviewJob = useMemo(
     () => reviewJobs.find((job) => job.id === selectedReviewJobId) ?? null,
     [reviewJobs, selectedReviewJobId]
+  );
+  const selectedReviewGeneration = useMemo(
+    () => reviewGenerationOptions.find((entry) => entry.job.id === selectedReviewJobId) ?? null,
+    [reviewGenerationOptions, selectedReviewJobId]
   );
   const editingPersona = useMemo(
     () => personas.find((persona) => persona.id === editingPersonaId) ?? null,
@@ -748,10 +796,7 @@ function HomePageContent() {
     try {
       const jobs = await apiFetch<ReviewJobRead[]>(`/review-jobs?document_version_id=${versionId}`);
       setReviewJobs(jobs);
-      const latestCompleted = [...jobs]
-        .reverse()
-        .find((job) => job.status === 'completed' && Boolean(job.completed_at));
-      const preferred = latestCompleted ?? (jobs.length > 0 ? jobs[jobs.length - 1] : null);
+      const preferred = pickLatestReviewGenerationJob(jobs);
       setSelectedReviewJobId(preferred?.id ?? null);
       if (preferred) {
         const data = await loadComments(versionId, false, preferred.id);
@@ -782,8 +827,8 @@ function HomePageContent() {
       const selectedExists =
         currentSelected !== null && jobs.some((job) => job.id === currentSelected);
       if (!selectedExists) {
-        const latest = jobs[jobs.length - 1];
-        nextSelected = latest?.id ?? null;
+        const latestGeneration = pickLatestReviewGenerationJob(jobs);
+        nextSelected = latestGeneration?.id ?? null;
         setSelectedReviewJobId(nextSelected);
       }
       const running = jobs.some((job) => job.status === 'queued' || job.status === 'running');
@@ -795,6 +840,28 @@ function HomePageContent() {
       // Snapshot polling should not surface transient errors in the primary UI flow.
       return { jobs: [], selectedId: currentSelected };
     }
+  }
+
+  async function handleSelectReviewGeneration(reviewJobId: number) {
+    if (!selectedVersion) return;
+    const nextReviewJob = reviewJobs.find((job) => job.id === reviewJobId) ?? null;
+
+    setSelectedReviewJobId(reviewJobId);
+    setFocusedCommentId(null);
+    setHoveredCommentId(null);
+    setRecentCommentIds(new Set());
+
+    const scoped = await loadComments(selectedVersion.id, false, reviewJobId);
+    const generationLabel =
+      nextReviewJob?.generation_index && nextReviewJob.generation_index > 0
+        ? `v${nextReviewJob.generation_index}`
+        : `run #${reviewJobId}`;
+
+    setStatusMessage(
+      scoped.length > 0
+        ? `Showing ${scoped.length} comments for ${generationLabel}.`
+        : `No comments available yet for ${generationLabel}.`
+    );
   }
 
   async function handleRefreshCurrentComments() {
@@ -2968,7 +3035,7 @@ function HomePageContent() {
                 <div className="doc-meta">
                   {visibleComments.length} comments · {enabledPersonas.size} active agents
                   {selectedReviewJob
-                    ? ` · run #${selectedReviewJob.id} ${selectedReviewJob.status} (${selectedReviewJob.provider}/${selectedReviewJob.model})`
+                    ? ` · ${selectedReviewGeneration ? `v${selectedReviewGeneration.generation} ` : ''}run #${selectedReviewJob.id} ${selectedReviewJob.status} (${selectedReviewJob.provider}/${selectedReviewJob.model})${Number.isInteger(selectedReviewJob.comment_count) ? ` · ${selectedReviewJob.comment_count} comments` : ''}`
                     : ''}
                 </div>
               </div>
@@ -2991,6 +3058,12 @@ function HomePageContent() {
                 </div>
                 <span className="pill">{systemStatus?.redis.ok ? 'Live' : 'Paused'}</span>
                 <span className="pill">{selectedVersion.version_label}</span>
+                {selectedReviewGeneration && (
+                  <span className="pill">
+                    v{selectedReviewGeneration.generation}
+                    {selectedReviewGeneration.isLatest ? ' latest' : ''}
+                  </span>
+                )}
                 {selectedReviewJob && (
                   <span className="pill">
                     {selectedReviewJob.status === 'running' || selectedReviewJob.status === 'queued'
@@ -3127,6 +3200,24 @@ function HomePageContent() {
                     Meta
                   </button>
                 </div>
+                {reviewGenerationOptions.length > 1 && (
+                  <select
+                    aria-label="Review generation"
+                    className="input compact"
+                    value={selectedReviewJobId ?? reviewGenerationOptions[0]?.job.id ?? ''}
+                    onChange={(event) => {
+                      const nextReviewJobId = Number(event.target.value);
+                      if (!Number.isInteger(nextReviewJobId) || nextReviewJobId <= 0) return;
+                      void handleSelectReviewGeneration(nextReviewJobId);
+                    }}
+                  >
+                    {reviewGenerationOptions.map((entry) => (
+                      <option key={entry.job.id} value={entry.job.id}>
+                        {entry.label}
+                      </option>
+                    ))}
+                  </select>
+                )}
                 {commentViewMode === 'meta' && (
                   <>
                     <select
@@ -5422,6 +5513,41 @@ function isMetaSynthesisFailedStatus(status: string | null | undefined): boolean
   if (!status) return false;
   const normalized = status.trim().toLowerCase();
   return normalized === 'failed' || normalized === 'error';
+}
+
+function normalizeGenerationIndex(value: number | null | undefined): number | null {
+  if (!Number.isInteger(value) || Number(value) <= 0) return null;
+  return Number(value);
+}
+
+function pickLatestReviewGenerationJob(jobs: ReviewJobRead[]): ReviewJobRead | null {
+  if (jobs.length === 0) return null;
+
+  const flaggedLatest = jobs
+    .filter((job) => job.is_latest_for_version === true)
+    .sort((a, b) => {
+      const aGeneration = normalizeGenerationIndex(a.generation_index) ?? 0;
+      const bGeneration = normalizeGenerationIndex(b.generation_index) ?? 0;
+      if (aGeneration !== bGeneration) return bGeneration - aGeneration;
+      return b.id - a.id;
+    })[0];
+  if (flaggedLatest) return flaggedLatest;
+
+  const highestGeneration = jobs
+    .slice()
+    .sort((a, b) => {
+      const aGeneration = normalizeGenerationIndex(a.generation_index) ?? 0;
+      const bGeneration = normalizeGenerationIndex(b.generation_index) ?? 0;
+      if (aGeneration !== bGeneration) return bGeneration - aGeneration;
+      return b.id - a.id;
+    })[0];
+  if ((normalizeGenerationIndex(highestGeneration?.generation_index) ?? 0) > 0) {
+    return highestGeneration ?? null;
+  }
+
+  return jobs
+    .slice()
+    .sort((a, b) => b.id - a.id)[0] ?? null;
 }
 
 function metaStatusPollDelayForAttempt(attempt: number): number {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -142,6 +142,9 @@ export type ReviewJobRead = {
   trigger: string;
   provider: string;
   model: string;
+  generation_index?: number | null;
+  is_latest_for_version?: boolean | null;
+  comment_count?: number;
   completed_at: string | null;
   created_at: string;
 };

--- a/frontend/tests/reviewMode.test.tsx
+++ b/frontend/tests/reviewMode.test.tsx
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+let mockPathname = '/';
+let mockSearchParams = new URLSearchParams();
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParams.get(key),
+    has: (key: string) => mockSearchParams.has(key),
+    toString: () => mockSearchParams.toString()
+  })
+}));
+
+import HomePage from '../app/page';
+
+type ReviewJobFixture = {
+  id: number;
+  tenant_id: string;
+  document_version_id: number;
+  status: string;
+  trigger: string;
+  provider: string;
+  model: string;
+  generation_index?: number;
+  is_latest_for_version?: boolean;
+  comment_count?: number;
+  completed_at: string | null;
+  created_at: string;
+};
+
+let reviewJobsFixture: ReviewJobFixture[] = [];
+let commentsByRun: Record<number, string> = {};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+describe('review generation selector', () => {
+  beforeEach(() => {
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101&mode=individual');
+    pushMock.mockClear();
+    replaceMock.mockClear();
+
+    reviewJobsFixture = [
+      {
+        id: 700,
+        tenant_id: 'local-dev',
+        document_version_id: 401,
+        status: 'completed',
+        trigger: 'manual',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        generation_index: 1,
+        is_latest_for_version: false,
+        comment_count: 1,
+        completed_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      },
+      {
+        id: 701,
+        tenant_id: 'local-dev',
+        document_version_id: 401,
+        status: 'completed',
+        trigger: 'manual',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        generation_index: 2,
+        is_latest_for_version: true,
+        comment_count: 1,
+        completed_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      }
+    ];
+
+    commentsByRun = {
+      700: 'Older generation feedback',
+      701: 'Latest generation feedback',
+      703: 'Middle generation feedback',
+      705: 'Newest fallback generation feedback'
+    };
+
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        clear: () => {
+          store.clear();
+        }
+      }
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/documents/library')) {
+        return json([
+          {
+            id: 101,
+            title: 'Design Notes',
+            latest_version_number: 1,
+            latest_version_created_at: new Date().toISOString(),
+            latest_review_status: 'completed',
+            latest_review_job_id: 701
+          }
+        ]);
+      }
+
+      if (url.endsWith('/documents')) return json([]);
+
+      if (url.endsWith('/personas')) {
+        return json([
+          {
+            id: 1,
+            tenant_id: 'local-dev',
+            name: 'Clarity Editor',
+            description: 'Improves flow',
+            system_prompt: 'Review for clarity',
+            focus_areas: ['structure'],
+            tone: 'direct',
+            reference_notes: null,
+            output_requirements: {
+              format: 'bullet_list',
+              max_bullets: 4,
+              require_quote_excerpt: true,
+              require_actionable: true,
+              include_severity: false
+            },
+            examples: [],
+            is_default: true,
+            is_system_locked: true,
+            sort_order: 10,
+            color_theme: '#1d8a7a',
+            group_id: null,
+            is_active: true,
+            created_at: new Date().toISOString()
+          }
+        ]);
+      }
+
+      if (url.endsWith('/status')) {
+        return json({
+          redis: { ok: true, error: null },
+          llm: { provider: 'openai', ok: true, error: null, model: 'gpt-4o-mini' },
+          openai: { ok: true },
+          review_queue: 'review-jobs',
+          doc_repo_enabled: true
+        });
+      }
+
+      if (url.endsWith('/documents/101/history')) {
+        return json([
+          {
+            sha: 'abcdef1234567',
+            message: 'Update design notes',
+            authored_at: new Date().toISOString()
+          }
+        ]);
+      }
+
+      if (url.endsWith('/documents/101/versions')) {
+        return json([
+          {
+            id: 401,
+            tenant_id: 'local-dev',
+            document_id: 101,
+            version_label: 'Initial upload',
+            content: '# Design Notes',
+            created_at: new Date().toISOString()
+          }
+        ]);
+      }
+
+      if (url.includes('/review-jobs?document_version_id=401')) {
+        return json(reviewJobsFixture);
+      }
+
+      if (url.includes('/comments?document_version_id=401')) {
+        const parsed = new URL(url, 'http://localhost');
+        const reviewJobId = Number(parsed.searchParams.get('review_job_id') ?? '0');
+        const commentText = commentsByRun[reviewJobId];
+        if (!commentText) return json([]);
+
+        return json([
+          {
+            id: 9000 + reviewJobId,
+            tenant_id: 'local-dev',
+            persona_id: 1,
+            document_version_id: 401,
+            review_job_id: reviewJobId,
+            text: commentText,
+            start_offset: 0,
+            end_offset: 10,
+            excerpt: 'Design',
+            created_at: new Date().toISOString()
+          }
+        ]);
+      }
+
+      if (url.includes('/meta-reviews/latest?')) {
+        return json({ detail: 'Meta review run not found' }, 404);
+      }
+
+      if (init?.method === 'POST' || init?.method === 'PATCH' || init?.method === 'DELETE') {
+        return json({}, 204);
+      }
+
+      return json({});
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to the latest review generation and renders deterministic generation labels', async () => {
+    render(<HomePage />);
+
+    expect(await screen.findByText('Latest generation feedback')).toBeTruthy();
+
+    const selector = (await screen.findByLabelText('Review generation')) as HTMLSelectElement;
+    expect(selector.value).toBe('701');
+
+    const optionLabels = Array.from(selector.options).map((option) => option.textContent ?? '');
+    expect(optionLabels).toEqual([
+      'v2 (latest) · run #701 · completed · 1 comment',
+      'v1 · run #700 · completed · 1 comment'
+    ]);
+  });
+
+  it('switching generations scopes comments to the selected run only', async () => {
+    render(<HomePage />);
+
+    expect(await screen.findByText('Latest generation feedback')).toBeTruthy();
+
+    const selector = (await screen.findByLabelText('Review generation')) as HTMLSelectElement;
+    fireEvent.change(selector, { target: { value: '700' } });
+
+    expect(await screen.findByText('Older generation feedback')).toBeTruthy();
+    expect(screen.queryByText('Latest generation feedback')).toBeNull();
+
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((args) =>
+        String(args[0])
+      );
+      expect(calls.some((url) => url.includes('/comments?document_version_id=401&review_job_id=700'))).toBe(true);
+    });
+  });
+
+  it('falls back to deterministic generation ordering when metadata is not available yet', async () => {
+    reviewJobsFixture = [
+      {
+        id: 703,
+        tenant_id: 'local-dev',
+        document_version_id: 401,
+        status: 'completed',
+        trigger: 'manual',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        completed_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      },
+      {
+        id: 701,
+        tenant_id: 'local-dev',
+        document_version_id: 401,
+        status: 'completed',
+        trigger: 'manual',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        completed_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      },
+      {
+        id: 705,
+        tenant_id: 'local-dev',
+        document_version_id: 401,
+        status: 'completed',
+        trigger: 'manual',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        completed_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      }
+    ];
+
+    render(<HomePage />);
+
+    expect(await screen.findByText('Newest fallback generation feedback')).toBeTruthy();
+
+    const selector = (await screen.findByLabelText('Review generation')) as HTMLSelectElement;
+    const optionLabels = Array.from(selector.options).map((option) => option.textContent ?? '');
+
+    expect(selector.value).toBe('705');
+    expect(optionLabels).toEqual([
+      'v3 (latest) · run #705 · completed',
+      'v2 · run #703 · completed',
+      'v1 · run #701 · completed'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a review generation selector to the comment panel when multiple runs exist for a document version
- default to the latest generation deterministically (prefer `is_latest_for_version`, then highest `generation_index`, then newest run id)
- scope comments to the explicitly selected generation when switching runs (no generation overwrite in UI)
- surface generation metadata in the UI (`vN`, latest marker, optional comment counts) while staying compatible when metadata is absent

## Behavior delivered for #50
- latest review generation is selected by default
- users can switch generations via selector
- switching generations updates visible comments to selected run only
- historical generations remain preserved/selectable in deterministic order

## Tests
- new: `frontend/tests/reviewMode.test.tsx`
  - defaults to latest generation
  - switching generation scopes comments to selected run
  - deterministic fallback ordering/labels without generation metadata

## Validation
Local (pnpm equivalents in this harness):
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && NODE_ENV=test pnpm vitest run tests/pageControls.test.tsx tests/uploadFlow.test.ts tests/reviewMode.test.tsx`
  - passed (3 files, 27 tests)
- `cd /home/zob/src/OpinionatedDocReviewer-fe-m1/frontend && pnpm run build`
  - passed (Next.js production build succeeded)

Requested bun commands were attempted but `bun`/`bunx` are not available in this execution environment; CI will run bun-based workflow checks on PR.

## Dependency note
- Backend generation metadata foundation PR #104 is now merged into `main`; this frontend lane consumes those fields when present and remains backward compatible when absent.

Closes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dynamic dropdown selector to switch between multiple review generations.
  * Enhanced header pills now display generation information and latest status indicators.
  * Improved review job selection logic to intelligently pick the most relevant review version.

* **Tests**
  * Added comprehensive test suite for review generation selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->