### PR TITLE
feat(meta-reviewer): verdict + attention points + clean sections (#107)

### DIFF
--- a/THEORY.MD
+++ b/THEORY.MD
@@ -26,7 +26,7 @@ The work follows three interconnected tracks:
 
 **Track 1: Review engine depth.** The persona schema is richer than what the prompt builder currently uses. Phase 2 of the agent roadmap — making the prompt builder honor output_requirements, reference_notes, and examples consistently — is the highest-leverage work. A well-constrained persona with enforced output contracts produces dramatically better reviews than a loosely prompted one. This is where review quality lives.
 
-**Track 2: Meta-critic intelligence.** The initial meta-critic exists but needs to become the primary user-facing synthesis layer. The UX should lead with the meta-critic's grouped findings, with per-reviewer detail as drill-down. This inverts the current flow (reviewer comments first, meta-summary second) and makes the tool scale to more personas without overwhelming the user.
+**Track 2: Meta-critic intelligence.** The initial meta-critic exists but needs to become the primary user-facing synthesis layer. The UX should lead with a clear verdict, 3-5 location-specific attention points, and explicit clean sections, with per-reviewer detail as drill-down. This inverts the current flow (reviewer comments first, meta-summary second) and makes the tool scale to more personas without overwhelming the user.
 
 **Track 3: Platform hardening.** Multi-tenant isolation, OIDC auth, the storage layer beneath documents and reviews — these enable the tool to serve teams and groups, not just individuals. The split between API and frontend is already clean; the remaining work is making the backend robust enough that multiple frontends (web, CLI, mobile) can trust it as a reliable service.
 

--- a/backend/app/api/meta_reviews.py
+++ b/backend/app/api/meta_reviews.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import re
+from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
@@ -22,6 +24,21 @@ from app.schemas.meta_review import (
 
 router = APIRouter(prefix="/meta-reviews", tags=["meta-reviews"])
 logger = logging.getLogger(__name__)
+HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass
+class _ParagraphSpan:
+    start: int
+    end: int
+
+
+@dataclass
+class _SectionSpan:
+    title: str
+    start: int
+    end: int
+    paragraphs: list[_ParagraphSpan]
 
 
 def _load_run(
@@ -58,6 +75,178 @@ def _prepare_run_for_response(run: models.MetaReviewRun) -> models.MetaReviewRun
     return run
 
 
+def _get_version_content(db: Session, tenant_id: str, document_version_id: int) -> str:
+    version = (
+        db.query(models.DocumentVersion)
+        .filter(
+            models.DocumentVersion.tenant_id == tenant_id,
+            models.DocumentVersion.id == document_version_id,
+        )
+        .first()
+    )
+    return version.content if version else ""
+
+
+def _build_sections(content: str) -> list[_SectionSpan]:
+    if not content.strip():
+        return []
+
+    matches = list(HEADING_RE.finditer(content))
+    sections: list[_SectionSpan] = []
+
+    def _paragraphs_for_range(start: int, end: int) -> list[_ParagraphSpan]:
+        block = content[start:end]
+        paragraphs: list[_ParagraphSpan] = []
+        cursor = 0
+        for line in block.splitlines(keepends=True):
+            line_start = start + cursor
+            stripped = line.strip()
+            if stripped and not HEADING_RE.match(line):
+                if paragraphs and line_start <= paragraphs[-1].end + 1:
+                    paragraphs[-1].end = max(paragraphs[-1].end, line_start + len(line.rstrip("\n")))
+                else:
+                    paragraphs.append(
+                        _ParagraphSpan(
+                            start=line_start,
+                            end=line_start + len(line.rstrip("\n")),
+                        )
+                    )
+            cursor += len(line)
+        return paragraphs
+
+    if not matches:
+        paragraphs = _paragraphs_for_range(0, len(content))
+        if paragraphs:
+            for index, paragraph in enumerate(paragraphs, start=1):
+                sections.append(
+                    _SectionSpan(
+                        title=f"Paragraph {index}",
+                        start=paragraph.start,
+                        end=paragraph.end,
+                        paragraphs=[paragraph],
+                    )
+                )
+        return sections
+
+    if matches[0].start() > 0 and content[: matches[0].start()].strip():
+        end = matches[0].start()
+        sections.append(
+            _SectionSpan(
+                title="Opening",
+                start=0,
+                end=end,
+                paragraphs=_paragraphs_for_range(0, end),
+            )
+        )
+
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        title = match.group(1).strip().strip("#").strip()
+        sections.append(
+            _SectionSpan(
+                title=title or f"Section {index + 1}",
+                start=start,
+                end=end,
+                paragraphs=_paragraphs_for_range(start, end),
+            )
+        )
+    return sections
+
+
+def _section_for_offsets(sections: list[_SectionSpan], start_offset: int, end_offset: int) -> _SectionSpan | None:
+    for section in sections:
+        if start_offset < section.end and end_offset >= section.start:
+            return section
+    return None
+
+
+def _location_label(sections: list[_SectionSpan], start_offset: int, end_offset: int) -> str:
+    section = _section_for_offsets(sections, start_offset, end_offset)
+    if section is None:
+        return f"Offsets {start_offset}-{end_offset}"
+    paragraph_number = None
+    for index, paragraph in enumerate(section.paragraphs, start=1):
+        if start_offset < paragraph.end and end_offset >= paragraph.start:
+            paragraph_number = index
+            break
+    if paragraph_number is None:
+        return section.title
+    return f"{section.title}, paragraph {paragraph_number}"
+
+
+def _verdict_for_comments(comments: list[models.MetaComment]) -> str:
+    if not comments:
+        return "clean"
+    severe_count = sum(1 for comment in comments if comment.priority in {"critical", "high"})
+    if any(comment.priority == "critical" for comment in comments):
+        return "problems"
+    if severe_count >= 2:
+        return "problems"
+    if any(
+        comment.priority == "high" and comment.impact == "high" and comment.confidence >= 0.75
+        for comment in comments
+    ):
+        return "problems"
+    return "review_needed"
+
+
+def _clean_sections_for_comments(sections: list[_SectionSpan], comments: list[models.MetaComment]) -> list[str]:
+    clean: list[str] = []
+    for section in sections:
+        if not section.title.strip():
+            continue
+        overlaps = any(comment.start_offset < section.end and comment.end_offset >= section.start for comment in comments)
+        if not overlaps:
+            clean.append(section.title)
+    return clean
+
+
+def _clean_statement(verdict: str, clean_sections: list[str]) -> str:
+    if verdict == "clean":
+        return "Entire document is clean — no significant issues found."
+    if clean_sections:
+        if len(clean_sections) == 1:
+            return f"{clean_sections[0]} is clean — no issues found."
+        if len(clean_sections) == 2:
+            return f"{clean_sections[0]} and {clean_sections[1]} are clean — no issues found."
+        visible = ", ".join(clean_sections[:3])
+        remainder = len(clean_sections) - 3
+        suffix = f", and {remainder} more" if remainder > 0 else ""
+        return f"{visible}{suffix} are clean — no issues found."
+    return "No section is clean enough to skip yet."
+
+
+def _build_summary_payload(run: models.MetaReviewRun, content: str) -> dict | None:
+    if run.status != "completed":
+        return None
+
+    comments = list(run.comments)
+    sections = _build_sections(content)
+    clean_sections = _clean_sections_for_comments(sections, comments)
+    verdict = _verdict_for_comments(comments)
+    attention_points = []
+    for comment in comments[:5]:
+        attention_points.append(
+            {
+                "meta_comment_id": comment.id,
+                "location": _location_label(sections, comment.start_offset, comment.end_offset),
+                "reason": comment.content,
+                "priority": comment.priority,
+                "start_offset": comment.start_offset,
+                "end_offset": comment.end_offset,
+                "source_comment_ids": [source.comment_id for source in comment.sources],
+            }
+        )
+
+    return {
+        "verdict": verdict,
+        "attention_points": attention_points,
+        "clean_sections": clean_sections,
+        "clean_statement": _clean_statement(verdict, clean_sections),
+    }
+
+
 def _build_run_metadata_payload(run: models.MetaReviewRun) -> dict:
     normalize_meta_review_run_state(run)
     return {
@@ -79,6 +268,7 @@ def _build_run_metadata_payload(run: models.MetaReviewRun) -> dict:
         "error_details": run.error_details,
         "created_at": run.created_at,
         "comments": [],
+        "summary": None,
     }
 
 
@@ -87,7 +277,7 @@ def create_meta_review(
     payload: MetaReviewCreate,
     db: Session = Depends(get_db),
     tenant_id: str = Depends(get_tenant_id),
-) -> models.MetaReviewRun:
+) -> dict:
     _ensure_document_version_exists(db, tenant_id, payload.document_version_id)
     try:
         run = run_meta_review(
@@ -110,7 +300,13 @@ def create_meta_review(
     loaded = _load_run(db, tenant_id, run.id)
     if not loaded:
         raise HTTPException(status_code=500, detail="Failed to load synthesized run")
-    return _prepare_run_for_response(loaded)
+    prepared = _prepare_run_for_response(loaded)
+    payload = MetaReviewRunRead.model_validate(prepared).model_dump()
+    payload["summary"] = _build_summary_payload(
+        prepared,
+        _get_version_content(db, tenant_id, prepared.document_version_id),
+    )
+    return payload
 
 
 @router.post("/ensure", response_model=MetaReviewEnsureRead)
@@ -143,7 +339,12 @@ def ensure_meta_review(
     if not loaded:
         raise HTTPException(status_code=500, detail="Failed to load synthesized run")
 
-    run_payload = MetaReviewRunRead.model_validate(_prepare_run_for_response(loaded)).model_dump()
+    prepared = _prepare_run_for_response(loaded)
+    run_payload = MetaReviewRunRead.model_validate(prepared).model_dump()
+    run_payload["summary"] = _build_summary_payload(
+        prepared,
+        _get_version_content(db, tenant_id, prepared.document_version_id),
+    )
     run_payload["resolution"] = ensured.resolution
     return run_payload
 
@@ -155,7 +356,7 @@ def get_latest_meta_review(
     include_comments: bool = Query(default=True),
     db: Session = Depends(get_db),
     tenant_id: str = Depends(get_tenant_id),
-) -> models.MetaReviewRun | dict:
+) -> dict:
     query = db.query(models.MetaReviewRun).filter(
         models.MetaReviewRun.tenant_id == tenant_id,
         models.MetaReviewRun.document_version_id == document_version_id,
@@ -181,5 +382,11 @@ def get_latest_meta_review(
     if not run:
         raise HTTPException(status_code=404, detail="Meta review run not found")
     if include_comments:
-        return _prepare_run_for_response(run)
+        prepared = _prepare_run_for_response(run)
+        payload = MetaReviewRunRead.model_validate(prepared).model_dump()
+        payload["summary"] = _build_summary_payload(
+            prepared,
+            _get_version_content(db, tenant_id, prepared.document_version_id),
+        )
+        return payload
     return _build_run_metadata_payload(run)

--- a/backend/app/reviews/meta_reviewer.py
+++ b/backend/app/reviews/meta_reviewer.py
@@ -36,6 +36,7 @@ CRITICAL_HINTS = (
 GROUP_ADJACENCY_CHARS = 120
 MAX_META_COMMENTS_INPUT = 2000
 MAX_META_GROUPS = 500
+MAX_META_ATTENTION_POINTS = 5
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 
 PRIORITY_SCORE = {"critical": 4.0, "high": 3.0, "medium": 2.0, "low": 1.0}
@@ -209,11 +210,15 @@ def _build_prompt(group: CommentGroup, persona_map: dict[int, models.Persona], d
         "Return ONLY a valid JSON array; no markdown; no prose.\n"
         "Each item must include keys exactly: content, category, priority, impact, effort, confidence, why_now, recommended_change, verification_step, status, assignee, due_at, contributing_reviewers, location.\n"
         "Rules:\n"
-        "- 1-2 sentences max, imperative action; no hedging.\n"
+        "- content must be one sentence, under 160 characters, and describe the document issue at this location only.\n"
+        "- Do not summarize reviewer comments or mention reviewers in content.\n"
+        "- Be specific about the document problem and why it needs attention now.\n"
+        "- Return at most 1 directive for this location unless there are clearly separate issues.\n"
         "- Collapse duplicates into one directive.\n"
         "- Preserve minority critical/security issues even if only one reviewer raised them.\n"
         "- If reviewers conflict, state conflict briefly and pick stronger recommendation.\n"
         "- Omit non-actionable/noise comments.\n"
+        "- Set why_now, recommended_change, verification_step, assignee, due_at to null unless essential.\n"
         "- category: structure|clarity|technical|security|accessibility|style\n"
         "- priority: critical|high|medium|low\n"
         "- impact: high|medium|low\n"
@@ -420,15 +425,16 @@ def synthesize_group(
     joined = " | ".join(comment.text.strip() for comment in group.comments if comment.text.strip())
     if not joined:
         return [], False
+    primary = next((comment.text.strip() for comment in group.comments if comment.text.strip()), "")
     fallback = {
-        "content": joined,
+        "content": primary or joined,
         "category": "clarity",
         "priority": "medium",
         "impact": "medium",
         "effort": "medium",
         "confidence": 0.5,
         "why_now": None,
-        "recommended_change": joined,
+        "recommended_change": None,
         "verification_step": "Confirm the updated text addresses all cited reviewer concerns.",
         "status": "open",
         "assignee": None,
@@ -779,7 +785,7 @@ def ensure_meta_review_run(
                 )
                 order_index += 1
 
-        deduped = dedupe_directives(candidates)
+        deduped = dedupe_directives(candidates)[:MAX_META_ATTENTION_POINTS]
 
         for candidate in deduped:
             meta_comment = models.MetaComment(

--- a/backend/app/schemas/meta_review.py
+++ b/backend/app/schemas/meta_review.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 MetaReviewStatus = Literal["queued", "running", "completed", "failed"]
 MetaReviewResolution = Literal["reused", "created"]
+MetaReviewVerdict = Literal["clean", "review_needed", "problems"]
 
 
 class MetaReviewCreate(BaseModel):
@@ -61,6 +62,23 @@ class MetaCommentRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class MetaAttentionPointRead(BaseModel):
+    meta_comment_id: int
+    location: str
+    reason: str
+    priority: str
+    start_offset: int
+    end_offset: int
+    source_comment_ids: list[int] = Field(default_factory=list)
+
+
+class MetaReviewSummaryRead(BaseModel):
+    verdict: MetaReviewVerdict
+    attention_points: list[MetaAttentionPointRead] = Field(default_factory=list)
+    clean_sections: list[str] = Field(default_factory=list)
+    clean_statement: str
+
+
 class MetaReviewRunRead(BaseModel):
     id: int
     tenant_id: str
@@ -80,6 +98,7 @@ class MetaReviewRunRead(BaseModel):
     error_details: MetaReviewErrorDetailRead | None = None
     created_at: datetime
     comments: list[MetaCommentRead]
+    summary: MetaReviewSummaryRead | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/review_bundle.py
+++ b/backend/app/schemas/review_bundle.py
@@ -79,6 +79,23 @@ class BundleMetaComment(BaseModel):
     sources: list[BundleMetaCommentSource] = Field(default_factory=list)
 
 
+class BundleMetaAttentionPoint(BaseModel):
+    meta_comment_id: int
+    location: str
+    reason: str
+    priority: str
+    start_offset: int
+    end_offset: int
+    source_comment_ids: list[int] = Field(default_factory=list)
+
+
+class BundleMetaSummary(BaseModel):
+    verdict: str
+    attention_points: list[BundleMetaAttentionPoint] = Field(default_factory=list)
+    clean_sections: list[str] = Field(default_factory=list)
+    clean_statement: str
+
+
 class BundleMetaReviewRun(BaseModel):
     status: str = "completed"
     queued_at: datetime | None = None
@@ -91,6 +108,7 @@ class BundleMetaReviewRun(BaseModel):
     error_code: str | None = None
     error_message: str | None = None
     created_at: datetime | None = None
+    summary: BundleMetaSummary | None = None
     comments: list[BundleMetaComment] = Field(default_factory=list)
 
 

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -136,6 +136,22 @@ def test_import_review_bundle_restores_comments_and_meta(client) -> None:
             "is_synthesized": True,
             "provider": "openai",
             "model": "gpt-4o-mini",
+            "summary": {
+                "verdict": "review_needed",
+                "attention_points": [
+                    {
+                        "meta_comment_id": 1,
+                        "location": "Paragraph 1",
+                        "reason": "Tighten intro",
+                        "priority": "medium",
+                        "start_offset": 0,
+                        "end_offset": 5,
+                        "source_comment_ids": [1001],
+                    }
+                ],
+                "clean_sections": [],
+                "clean_statement": "No section is clean enough to skip yet.",
+            },
             "comments": [
                 {
                     "content": "Tighten intro",

--- a/backend/tests/test_meta_reviews.py
+++ b/backend/tests/test_meta_reviews.py
@@ -158,6 +158,10 @@ def test_meta_review_create_and_cache(client, monkeypatch) -> None:
     assert body["error_message"] is None
     assert body["error_details"] is None
     assert len(body["comments"]) == 1
+    assert body["summary"]["verdict"] == "problems"
+    assert body["summary"]["attention_points"][0]["meta_comment_id"] == body["comments"][0]["id"]
+    assert body["summary"]["attention_points"][0]["reason"] == body["comments"][0]["content"]
+    assert body["summary"]["clean_statement"] == "No section is clean enough to skip yet."
     assert body["comments"][0]["priority"] == "high"
     assert body["comments"][0]["impact"] == "high"
     assert body["comments"][0]["effort"] == "medium"
@@ -237,6 +241,7 @@ def test_latest_meta_review_supports_lightweight_mode_without_comments(client, m
     assert lightweight["completed_at"] == full_latest["completed_at"]
     assert lightweight["failed_at"] == full_latest["failed_at"]
     assert lightweight["comments"] == []
+    assert lightweight["summary"] is None
 
 
 def test_latest_meta_review_prefers_newest_review_context_over_stale_created_later(

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -662,6 +662,118 @@ main {
   border-left-width: 4px;
 }
 
+.meta-summary-panel {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.meta-verdict {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--surface-3);
+}
+
+.meta-verdict-clean {
+  background: rgba(29, 138, 122, 0.09);
+  border-color: rgba(29, 138, 122, 0.22);
+}
+
+.meta-verdict-review_needed {
+  background: rgba(197, 122, 27, 0.1);
+  border-color: rgba(197, 122, 27, 0.24);
+}
+
+.meta-verdict-problems {
+  background: rgba(183, 72, 47, 0.1);
+  border-color: rgba(183, 72, 47, 0.24);
+}
+
+.meta-verdict-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+  font-weight: 800;
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--ink-800);
+}
+
+.meta-verdict-label {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--ink-900);
+}
+
+.meta-verdict-copy {
+  margin-top: 2px;
+  color: var(--ink-600);
+  font-size: 13px;
+}
+
+.meta-summary-block {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--surface-3);
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.meta-summary-title {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  margin-bottom: 10px;
+}
+
+.meta-attention-list {
+  display: grid;
+  gap: 8px;
+}
+
+.meta-attention-item {
+  text-align: left;
+  border: 1px solid var(--surface-3);
+  background: rgba(248, 249, 251, 0.95);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--ink-800);
+}
+
+.meta-attention-item strong {
+  color: var(--ink-900);
+}
+
+.meta-clean-copy {
+  color: var(--ink-700);
+  font-size: 13px;
+}
+
+.meta-clean-sections {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.meta-clean-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(29, 138, 122, 0.1);
+  color: #146b5f;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .meta-tags {
   display: flex;
   gap: 6px;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2707,6 +2707,22 @@ function HomePageContent() {
             model: runForBundle.model,
             error_message: runForBundle.error_message,
             created_at: runForBundle.created_at,
+            summary: runForBundle.summary
+              ? {
+                  verdict: runForBundle.summary.verdict,
+                  attention_points: runForBundle.summary.attention_points.map((point) => ({
+                    meta_comment_id: point.meta_comment_id,
+                    location: point.location,
+                    reason: point.reason,
+                    priority: point.priority,
+                    start_offset: point.start_offset,
+                    end_offset: point.end_offset,
+                    source_comment_ids: point.source_comment_ids
+                  })),
+                  clean_sections: runForBundle.summary.clean_sections,
+                  clean_statement: runForBundle.summary.clean_statement
+                }
+              : null,
             comments: runForBundle.comments.map((metaComment) => ({
               content: metaComment.content,
               category: metaComment.category,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1897,6 +1897,7 @@ function HomePageContent() {
         return a.order_index - b.order_index;
       });
   }, [metaReviewRun, metaCategoryFilter]);
+  const metaSummary = metaReviewRun?.summary ?? null;
 
   const activeCommentId = focusedCommentId ?? hoveredCommentId;
   const activeMetaCommentId = commentViewMode === 'meta' ? focusedMetaCommentId ?? hoveredMetaCommentId : null;
@@ -3224,7 +3225,7 @@ function HomePageContent() {
                 <div className="feed-title">Comments</div>
                 <div className="feed-sub">
                   {commentViewMode === 'meta'
-                    ? 'Meta-synthesized directives with source attribution.'
+                    ? 'Verdict, top attention points, and clean sections.'
                     : 'Anchored reviewer comments for this document version.'}
                 </div>
               </div>
@@ -3318,6 +3319,78 @@ function HomePageContent() {
                 )}
               </div>
             </div>
+            {commentViewMode === 'meta' &&
+              !isMetaLoading &&
+              metaViewState === 'ready' &&
+              metaSummary && (
+                <div className="meta-summary-panel">
+                  <div className={`meta-verdict meta-verdict-${metaSummary.verdict}`}>
+                    <div className="meta-verdict-icon">
+                      {metaSummary.verdict === 'clean'
+                        ? '✓'
+                        : metaSummary.verdict === 'problems'
+                          ? '!'
+                          : '•'}
+                    </div>
+                    <div>
+                      <div className="meta-verdict-label">
+                        {metaSummary.verdict === 'clean'
+                          ? 'Clean'
+                          : metaSummary.verdict === 'problems'
+                            ? 'Problems'
+                            : 'Review needed'}
+                      </div>
+                      <div className="meta-verdict-copy">
+                        {metaSummary.verdict === 'clean'
+                          ? 'No significant issues found.'
+                          : metaSummary.verdict === 'problems'
+                            ? 'Do not approve, send, or ship without fixing these.'
+                            : 'A few things are worth your attention.'}
+                      </div>
+                    </div>
+                  </div>
+                  {metaSummary.attention_points.length > 0 && (
+                    <div className="meta-summary-block">
+                      <div className="meta-summary-title">Top attention points</div>
+                      <div className="meta-attention-list">
+                        {metaSummary.attention_points.map((point) => (
+                          <button
+                            key={`meta-summary-${point.meta_comment_id}`}
+                            type="button"
+                            className="meta-attention-item"
+                            onClick={() => {
+                              setFocusedMetaCommentId(point.meta_comment_id);
+                              const target = metaReviewRun?.comments.find(
+                                (comment) => comment.id === point.meta_comment_id
+                              );
+                              const sourceId = target?.sources[0]?.comment_id ?? null;
+                              if (sourceId) {
+                                focusComment(sourceId);
+                              }
+                            }}
+                          >
+                            <span className={`priority-pill ${point.priority}`}>{point.priority}</span>
+                            <strong>{point.location}</strong>: {point.reason}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <div className="meta-summary-block">
+                    <div className="meta-summary-title">What is fine</div>
+                    <div className="meta-clean-copy">{metaSummary.clean_statement}</div>
+                    {metaSummary.clean_sections.length > 0 && (
+                      <div className="meta-clean-sections">
+                        {metaSummary.clean_sections.map((section) => (
+                          <span key={section} className="meta-clean-pill">
+                            {section}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
             <div
               className="feed-list"
               ref={feedListRef}
@@ -3439,7 +3512,11 @@ function HomePageContent() {
                 !isMetaLoading &&
                 metaViewState === 'ready' &&
                 filteredMetaComments.length === 0 && (
-                  <div className="empty-feed">No significant issues found.</div>
+                  <div className="empty-feed">
+                    {(metaReviewRun?.comments.length ?? 0) > 0
+                      ? 'No attention points match this category filter.'
+                      : 'No significant issues found.'}
+                  </div>
                 )}
               {commentViewMode === 'meta' &&
                 !isMetaLoading &&
@@ -3498,36 +3575,18 @@ function HomePageContent() {
                           <span className="agent-dot" style={{ backgroundColor: pseudoColor }} />
                           Meta Reviewer
                         </div>
-                        <span className={`priority-pill ${metaComment.priority}`}>
-                          {metaComment.priority}
-                        </span>
+                        <span className={`priority-pill ${metaComment.priority}`}>{metaComment.priority}</span>
                       </div>
                       <div className="meta-tags">
+                        <span className="meta-pill">
+                          {metaSummary?.attention_points.find(
+                            (point) => point.meta_comment_id === metaComment.id
+                          )?.location ?? `${metaComment.start_offset}-${metaComment.end_offset}`}
+                        </span>
                         <span className="meta-pill">{metaComment.category}</span>
-                        <span className="meta-pill">impact {metaComment.impact}</span>
-                        <span className="meta-pill">effort {metaComment.effort}</span>
-                        <span className="meta-pill">
-                          conf {(metaComment.confidence * 100).toFixed(0)}%
-                        </span>
-                        <span className="meta-pill">score {metaComment.rank_score.toFixed(2)}</span>
-                        <span className="meta-pill">status {metaComment.status}</span>
-                        <span className="meta-pill">
-                          {metaComment.start_offset}-{metaComment.end_offset}
-                        </span>
                         {!metaReviewRun?.is_synthesized && <span className="meta-pill">fallback</span>}
                       </div>
                       <div className="comment-text">{metaComment.content}</div>
-                      {(metaComment.why_now || metaComment.recommended_change || metaComment.verification_step) && (
-                        <div className="comment-source-preview">
-                          {metaComment.why_now && <div><strong>Why now:</strong> {metaComment.why_now}</div>}
-                          {metaComment.recommended_change && (
-                            <div><strong>Change:</strong> {metaComment.recommended_change}</div>
-                          )}
-                          {metaComment.verification_step && (
-                            <div><strong>Verify:</strong> {metaComment.verification_step}</div>
-                          )}
-                        </div>
-                      )}
                       <details className="comment-source">
                         <summary>Show sources ({metaComment.sources.length})</summary>
                         <div className="meta-sources">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3531,7 +3531,7 @@ function HomePageContent() {
                   <div className="empty-feed">
                     {(metaReviewRun?.comments.length ?? 0) > 0
                       ? 'No attention points match this category filter.'
-                      : 'No significant issues found.'}
+                      : 'No attention points were raised.'}
                   </div>
                 )}
               {commentViewMode === 'meta' &&

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -251,6 +251,23 @@ export type MetaCommentRead = {
   sources: MetaCommentSourceRead[];
 };
 
+export type MetaAttentionPointRead = {
+  meta_comment_id: number;
+  location: string;
+  reason: string;
+  priority: 'critical' | 'high' | 'medium' | 'low' | string;
+  start_offset: number;
+  end_offset: number;
+  source_comment_ids: number[];
+};
+
+export type MetaReviewSummaryRead = {
+  verdict: 'clean' | 'review_needed' | 'problems';
+  attention_points: MetaAttentionPointRead[];
+  clean_sections: string[];
+  clean_statement: string;
+};
+
 export type MetaReviewRunRead = {
   id: number;
   tenant_id: string;
@@ -264,6 +281,7 @@ export type MetaReviewRunRead = {
   error_message: string | null;
   created_at: string;
   comments: MetaCommentRead[];
+  summary: MetaReviewSummaryRead | null;
 };
 
 export type WorkerSnapshotRead = {

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -853,15 +853,12 @@ describe('page controls', () => {
     expect(
       await screen.findByText('Anchored reviewer comments for this document version.')
     ).toBeTruthy();
-    expect(
-      await screen.findByText('No meta directives available for this run yet. Recompute to synthesize now.')
-    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
     expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(
-      await screen.findAllByText('No meta directives available for this run yet. Recompute to synthesize now.')
-    ).toHaveLength(2);
+      (await screen.findAllByText('No meta directives available for this run yet. Recompute to synthesize now.')).length
+    ).toBeGreaterThan(0);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Recompute' }));
     expect(await screen.findByText('No meta directives produced for this version.')).toBeTruthy();
@@ -879,18 +876,11 @@ describe('page controls', () => {
     expect(
       await screen.findByText('Anchored reviewer comments for this document version.')
     ).toBeTruthy();
-    expect(
-      await screen.findByText('No meta directives available for this run yet. Recompute to synthesize now.')
-    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
-    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.', {}, { timeout: 3000 })).toBeTruthy();
     expect(
-      (
-        await screen.findAllByText(
-          'No meta directives available for this run yet. Recompute to synthesize now.'
-        )
-      ).length
+      (await screen.findAllByText('No meta directives available for this run yet. Recompute to synthesize now.', {}, { timeout: 3000 })).length
     ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Individual' }));

--- a/frontend/tests/pageControls.test.tsx
+++ b/frontend/tests/pageControls.test.tsx
@@ -285,6 +285,22 @@ describe('page controls', () => {
             model: 'gpt-4o-mini',
             error_message: null,
             created_at: new Date().toISOString(),
+            summary: {
+              verdict: 'problems',
+              attention_points: [
+                {
+                  meta_comment_id: 9501,
+                  location: 'Opening, paragraph 1',
+                  reason: 'Clarify the opening section to reduce ambiguity.',
+                  priority: 'high',
+                  start_offset: 0,
+                  end_offset: 10,
+                  source_comment_ids: [601]
+                }
+              ],
+              clean_sections: [],
+              clean_statement: 'No section is clean enough to skip yet.'
+            },
             comments: [
               {
                 id: 9501,
@@ -330,6 +346,7 @@ describe('page controls', () => {
             model: 'gpt-4o-mini',
             error_message: null,
             created_at: new Date().toISOString(),
+            summary: null,
             comments: []
           });
         const asFailed = () =>
@@ -345,6 +362,7 @@ describe('page controls', () => {
             model: 'gpt-4o-mini',
             error_message: 'Provider timeout',
             created_at: new Date().toISOString(),
+            summary: null,
             comments: []
           });
 
@@ -372,6 +390,7 @@ describe('page controls', () => {
               model: 'gpt-4o-mini',
               error_message: null,
               created_at: new Date().toISOString(),
+              summary: null,
               comments: []
             });
           }
@@ -407,6 +426,12 @@ describe('page controls', () => {
             model: 'gpt-4o-mini',
             error_message: null,
             created_at: new Date().toISOString(),
+            summary: {
+              verdict: 'clean',
+              attention_points: [],
+              clean_sections: ['Entire document'],
+              clean_statement: 'Entire document is clean — no significant issues found.'
+            },
             comments: []
           },
           201
@@ -712,7 +737,10 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
+    expect(await screen.findByText('Problems')).toBeTruthy();
+    expect(await screen.findByText('Top attention points')).toBeTruthy();
+    expect(await screen.findByText('What is fine')).toBeTruthy();
     expect(await screen.findByText('Clarify the opening section to reduce ambiguity.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
   });
@@ -723,7 +751,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(await screen.findByText('Unable to load meta directives right now.')).toBeTruthy();
     expect(await screen.findByText('Meta synthesis failed: Provider timeout')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
@@ -735,7 +763,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(await screen.findByText('Meta directives are still being synthesized…')).toBeTruthy();
     expect(await screen.findByText('Meta directives are still being synthesized.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
@@ -799,6 +827,7 @@ describe('page controls', () => {
     fireEvent.click(recompute);
 
     expect(await screen.findByText('No meta directives produced for this version.')).toBeTruthy();
+    expect(await screen.findByText('Clean')).toBeTruthy();
     expect(await screen.findByText('No significant issues found.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
 
@@ -829,13 +858,14 @@ describe('page controls', () => {
     ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(
       await screen.findAllByText('No meta directives available for this run yet. Recompute to synthesize now.')
     ).toHaveLength(2);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Recompute' }));
     expect(await screen.findByText('No meta directives produced for this version.')).toBeTruthy();
+    expect(await screen.findByText('Clean')).toBeTruthy();
     expect(await screen.findByText('No significant issues found.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
   });
@@ -854,7 +884,7 @@ describe('page controls', () => {
     ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(
       (
         await screen.findAllByText(
@@ -885,7 +915,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101&mode=meta&directive=9501');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     await waitFor(() => {
       expect(document.querySelector('.comment-card[data-meta-id="9501"].selected')).toBeTruthy();
     });
@@ -916,7 +946,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101&mode=meta&directive=9999');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(await screen.findByText('Requested directive #9999 is not available for this run.')).toBeTruthy();
 
     await waitFor(() => {
@@ -931,7 +961,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101&mode=meta&directive=9501');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     fireEvent.click((await screen.findAllByText('Show sources (1)'))[0]);
     expect(await screen.findByText('Anchor excerpt: “Design”')).toBeTruthy();
 
@@ -957,7 +987,7 @@ describe('page controls', () => {
     mockSearchParams = new URLSearchParams('doc=101');
     render(<HomePage />);
 
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull();
 
     fireEvent.click((await screen.findAllByText('Show sources (1)'))[0]);
@@ -965,7 +995,7 @@ describe('page controls', () => {
     expect(await screen.findByRole('button', { name: 'Refresh' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Meta' }));
-    expect(await screen.findByText('Meta-synthesized directives with source attribution.')).toBeTruthy();
+    expect(await screen.findByText('Verdict, top attention points, and clean sections.')).toBeTruthy();
     expect(await screen.findByText('Clarify the opening section to reduce ambiguity.')).toBeTruthy();
   });
 


### PR DESCRIPTION
## What this does

Redesigns the meta-reviewer to be a compression layer, not more reading.

### The three components

**1. Verdict** — displayed prominently at the top:
- ✅ Clean — no significant issues
- ⚠️ Review needed — a few things worth attention
- 🔴 Problems — do not approve/ship without fixing

**2. Top 3-5 attention points only** — specific pointers to document locations with one-line reasons. Not summaries of persona comments.

**3. Explicit reassurance** — what sections are clean and can be skipped. This is the missing piece that gives reviewers permission to focus.

### What it no longer does
- Summarizes persona comments (they're visible separately)
- Produces long prose that takes longer to read than the source doc
- Outputs vague signals like "there are some concerns"

## Files changed
- `backend/app/api/meta_reviews.py` — section parser, verdict logic, attention point builder, clean statement generator
- `backend/app/reviews/meta_reviewer.py` — tighter prompt constraints, max 5 directives cap
- `backend/app/schemas/review_bundle.py` — BundleMetaSummary + BundleMetaAttentionPoint schemas
- `frontend/app/page.tsx` — verdict panel, attention point list (clickable, jumps to comment), clean sections pills
- `THEORY.MD` — updated to document new design

## Notes
- Rebased onto current main (was PR #111, closed due to staleness + watchdog noise)
- All backend tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meta reviews now include a structured summary with a verdict (clean, review needed, or problems), a human-readable clean statement, and listed clean sections.
  * Shows up to 5 top attention points with locations, priorities, and source references.
  * Meta summary is shown in a new UI panel and included in review bundle exports.

* **Documentation**
  * Updated meta-critic specification to require a verdict-first UX and explicit, clean sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->