### PR TITLE
fix(correctness): cross-doc review mixup + frontend races + security defaults (P0)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -118,7 +118,8 @@ class Settings(BaseSettings):
     OIDC_NAME_CLAIM: str = "name"
     OIDC_ROLES_CLAIM: str = "roles"
     OIDC_ADMIN_ROLE: str = "admin"
-    OIDC_ALLOW_LOCAL_HEADER_FALLBACK: bool = True
+    OIDC_ALLOW_LOCAL_HEADER_FALLBACK: bool = False
+    MAX_REQUEST_BODY_BYTES: int = 5 * 1024 * 1024
     LOCAL_AUTH_JWT_SECRET: str = "change-me-local-auth-secret"
     LOCAL_AUTH_JWT_ALGORITHM: str = "HS256"
     LOCAL_AUTH_ACCESS_TOKEN_TTL_MINUTES: int = 720

--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -1,8 +1,13 @@
+import logging
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.db import models
+from app.reviews.git_repo import remove_repo
 from app.schemas.document import DocumentCreate, DocumentUpdate
+
+logger = logging.getLogger(__name__)
 
 
 def create_document(db: Session, tenant_id: str, data: DocumentCreate) -> models.Document:
@@ -10,6 +15,21 @@ def create_document(db: Session, tenant_id: str, data: DocumentCreate) -> models
     db.add(doc)
     db.commit()
     db.refresh(doc)
+    if settings.DOC_REPO_ENABLED:
+        try:
+            removed = remove_repo(tenant_id, doc.id)
+            if removed:
+                logger.warning(
+                    "stale_doc_repo_cleaned tenant_id=%s document_id=%s",
+                    tenant_id,
+                    doc.id,
+                )
+        except Exception:
+            logger.exception(
+                "stale_doc_repo_cleanup_failed tenant_id=%s document_id=%s",
+                tenant_id,
+                doc.id,
+            )
     return doc
 
 
@@ -53,6 +73,15 @@ def delete_document(db: Session, tenant_id: str, document_id: int) -> bool:
         return False
     db.delete(doc)
     db.commit()
+    if settings.DOC_REPO_ENABLED:
+        try:
+            remove_repo(tenant_id, document_id)
+        except Exception:
+            logger.exception(
+                "doc_repo_cleanup_failed tenant_id=%s document_id=%s",
+                tenant_id,
+                document_id,
+            )
     return True
 
 

--- a/backend/app/crud/document_version.py
+++ b/backend/app/crud/document_version.py
@@ -12,9 +12,6 @@ def create_version(
     document_id: int,
     data: DocumentVersionCreate,
 ) -> models.DocumentVersion:
-    if settings.DOC_REPO_ENABLED:
-        repo = ensure_repo(tenant_id, document_id)
-        write_and_commit(repo, data.content, f"{data.version_label}")
     version = models.DocumentVersion(
         tenant_id=tenant_id,
         document_id=document_id,
@@ -24,6 +21,9 @@ def create_version(
     db.add(version)
     db.commit()
     db.refresh(version)
+    if settings.DOC_REPO_ENABLED:
+        repo = ensure_repo(tenant_id, document_id)
+        write_and_commit(repo, data.content, f"{data.version_label}")
     return version
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -52,8 +52,12 @@ class Persona(Base):
 
 class Document(Base):
     __tablename__ = "documents"
+    # Prevent SQLite rowid reuse after DELETE: a new row must never take the
+    # id of a previously-deleted document, because stale on-disk artifacts
+    # (git repos, queued jobs) reference documents by id.
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     title: Mapped[str] = mapped_column(String(300), index=True)
     tags: Mapped[list] = mapped_column(JSON, default=list)
@@ -73,8 +77,9 @@ class Document(Base):
 
 class DocumentVersion(Base):
     __tablename__ = "document_versions"
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     document_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("documents.id", ondelete="CASCADE")
@@ -90,8 +95,9 @@ class DocumentVersion(Base):
 
 class ReviewJob(Base):
     __tablename__ = "review_jobs"
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     document_version_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("document_versions.id", ondelete="CASCADE"), index=True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from app.api.routes import api_router
 from app.core.config import settings
 from app.db.init_db import init_db
+from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.csrf_guard import CsrfOriginGuardMiddleware
 from app.middleware.request_log import RequestLogMiddleware
 from app.middleware.rate_limit import SimpleRateLimitMiddleware
@@ -34,6 +35,7 @@ def create_app(init_db_on_startup: bool = True) -> FastAPI:
         allow_headers=settings.cors_allow_headers_list,
         max_age=settings.CORS_MAX_AGE,
     )
+    app.add_middleware(BodySizeLimitMiddleware)
     app.add_middleware(SimpleRateLimitMiddleware)
     app.add_middleware(CsrfOriginGuardMiddleware)
     app.add_middleware(RequestLogMiddleware)

--- a/backend/app/middleware/body_size_limit.py
+++ b/backend/app/middleware/body_size_limit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+from app.core.config import settings
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared body size exceeds MAX_REQUEST_BODY_BYTES.
+
+    Relies on the Content-Length header for a cheap fast-path check so we do
+    not buffer large bodies. Requests without a Content-Length (chunked
+    transfer encoding, streaming uploads) fall through to downstream
+    per-route validation, which is where schema-level size limits apply for
+    fields like document content.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        limit = settings.MAX_REQUEST_BODY_BYTES
+        if limit and limit > 0:
+            content_length = request.headers.get("content-length")
+            if content_length:
+                try:
+                    declared = int(content_length)
+                except ValueError:
+                    return JSONResponse(
+                        {"detail": "Invalid Content-Length header"},
+                        status_code=400,
+                    )
+                if declared > limit:
+                    return JSONResponse(
+                        {"detail": "Request body too large"},
+                        status_code=413,
+                    )
+        return await call_next(request)

--- a/backend/app/reviews/git_repo.py
+++ b/backend/app/reviews/git_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from app.core.config import settings
 from app.security.tenant import validate_tenant_id
 
 
-def ensure_repo(tenant_id: str, document_id: int) -> Path:
+def _resolve_repo_path(tenant_id: str, document_id: int) -> tuple[Path, Path]:
     if document_id <= 0:
         raise HTTPException(status_code=400, detail="Invalid document id")
     safe_tenant_id = validate_tenant_id(tenant_id)
@@ -18,6 +19,11 @@ def ensure_repo(tenant_id: str, document_id: int) -> Path:
     repo_path = (root / safe_tenant_id / f"doc-{document_id}").resolve()
     if not repo_path.is_relative_to(root):
         raise HTTPException(status_code=400, detail="Invalid repository path")
+    return root, repo_path
+
+
+def ensure_repo(tenant_id: str, document_id: int) -> Path:
+    _, repo_path = _resolve_repo_path(tenant_id, document_id)
     repo_path.mkdir(parents=True, exist_ok=True)
     git_dir = repo_path / ".git"
     if not git_dir.exists():
@@ -25,6 +31,22 @@ def ensure_repo(tenant_id: str, document_id: int) -> Path:
         _run_git(["config", "user.email", "reviews@local"], cwd=repo_path)
         _run_git(["config", "user.name", "OpinionatedDocReviewer"], cwd=repo_path)
     return repo_path
+
+
+def remove_repo(tenant_id: str, document_id: int) -> bool:
+    """Remove the git-backed document repo for a deleted document.
+
+    Prevents stale history from being inherited by a new document that
+    reuses the same database id (e.g. SQLite rowid reuse after DELETE).
+    Safe to call even when the repo does not yet exist.
+    """
+    root, repo_path = _resolve_repo_path(tenant_id, document_id)
+    if not repo_path.exists():
+        return False
+    if not repo_path.is_relative_to(root):
+        raise HTTPException(status_code=400, detail="Invalid repository path")
+    shutil.rmtree(repo_path, ignore_errors=False)
+    return True
 
 
 def write_and_commit(repo_path: Path, content: str, message: str) -> str:

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -153,6 +153,29 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
             db.commit()
             return
 
+        # Defense against doc-id reuse: if the parent document has been
+        # deleted between enqueue and dequeue, abort rather than writing
+        # comments that could attach to a new document with a reused id.
+        parent_document = (
+            db.query(models.Document)
+            .filter(
+                models.Document.id == version.document_id,
+                models.Document.tenant_id == tenant_id,
+            )
+            .first()
+        )
+        if not parent_document:
+            logger.warning(
+                "review_job_aborted_parent_missing tenant_id=%s review_job_id=%s version_id=%s document_id=%s",
+                tenant_id,
+                review_job_id,
+                version.id,
+                version.document_id,
+            )
+            job.status = "failed"
+            db.commit()
+            return
+
         personas = _list_active_personas_for_execution(db, tenant_id)
         if not personas:
             seed_default_personas(tenant_id=tenant_id, db=db)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from app.core.config import settings
 
 
@@ -77,6 +79,54 @@ def test_document_and_versions_crud(client) -> None:
 
     get_missing = client.get(f"/api/documents/{doc_id}", headers=headers)
     assert get_missing.status_code == 404
+
+
+def test_delete_document_removes_git_repo_and_prevents_id_reuse(
+    client, tmp_path, monkeypatch
+) -> None:
+    """Regression: deleting a document must (a) clean the git-backed
+    history directory and (b) not leak that history to a subsequently
+    created document. Previously the doc-repos/<tenant>/doc-<id>
+    directory persisted after delete, and SQLite rowid reuse could give
+    a new document the same id, inheriting the old history plus any
+    in-flight comments.
+    """
+    monkeypatch.setattr(settings, "DOC_REPO_ROOT", str(tmp_path / "doc-repos"))
+    monkeypatch.setattr(settings, "DOC_REPO_ENABLED", True)
+
+    headers = {"X-Tenant-Id": "tenant-reuse"}
+
+    doc_a = client.post("/api/documents", json={"title": "Doc A"}, headers=headers).json()
+    version_a = client.post(
+        f"/api/documents/{doc_a['id']}/versions",
+        json={"version_label": "v1", "content": "Alpha content"},
+        headers=headers,
+    )
+    assert version_a.status_code == 201
+
+    repo_a_path = Path(settings.DOC_REPO_ROOT) / "tenant-reuse" / f"doc-{doc_a['id']}"
+    assert repo_a_path.exists(), "repo should be created for doc A"
+    assert (repo_a_path / ".git").exists()
+
+    delete_resp = client.delete(f"/api/documents/{doc_a['id']}", headers=headers)
+    assert delete_resp.status_code == 204
+    assert not repo_a_path.exists(), "git repo must be removed on delete"
+
+    doc_b = client.post("/api/documents", json={"title": "Doc B"}, headers=headers).json()
+    assert doc_b["id"] != doc_a["id"], (
+        "SQLite AUTOINCREMENT must prevent id reuse across deletes"
+    )
+
+    version_b = client.post(
+        f"/api/documents/{doc_b['id']}/versions",
+        json={"version_label": "v1", "content": "Beta content"},
+        headers=headers,
+    )
+    assert version_b.status_code == 201
+
+    repo_b_path = Path(settings.DOC_REPO_ROOT) / "tenant-reuse" / f"doc-{doc_b['id']}"
+    commits = [p for p in repo_b_path.glob(".git/refs/heads/*") if p.is_file()]
+    assert commits, "doc B must have its own fresh git history"
 
 
 def test_document_version_content_size_limit(client) -> None:

--- a/backend/tests/test_security_controls.py
+++ b/backend/tests/test_security_controls.py
@@ -21,6 +21,20 @@ def test_git_repo_rejects_path_traversal_tenant() -> None:
         assert exc.status_code == 400
 
 
+def test_body_size_limit_rejects_oversized_content_length(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "MAX_REQUEST_BODY_BYTES", 1024)
+    response = client.post(
+        "/api/documents",
+        content=b"{}",
+        headers={
+            "X-Tenant-Id": "tenant-size",
+            "Content-Type": "application/json",
+            "Content-Length": str(10 * 1024),
+        },
+    )
+    assert response.status_code == 413
+
+
 def test_rate_limit_blocks_excess_requests(client, monkeypatch) -> None:
     monkeypatch.setattr(settings, "RATE_LIMIT_ENABLED", True)
     monkeypatch.setattr(settings, "RATE_LIMIT_WINDOW_SECONDS", 60)

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -246,6 +246,17 @@ function HomePageContent() {
   const hoveredMetaCommentIdRef = useRef<number | null>(null);
   const hoverAlignFrameRef = useRef<number | null>(null);
   const handledRouteIntentRef = useRef<string | null>(null);
+  // Selection-generation: bumped on every document switch. Async fetches
+  // capture the value at call time and drop their response if the user
+  // has switched to a different document before the response returns.
+  // This prevents stale polling/refresh responses from overwriting fresh
+  // state when the user rapidly switches between documents.
+  const selectedVersionIdRef = useRef<number | null>(null);
+  const selectedReviewJobIdRef = useRef<number | null>(null);
+  const selectionGenerationRef = useRef(0);
+  // Dedupe key for in-flight meta auto-loads so polling-driven status
+  // changes do not fire concurrent duplicate requests.
+  const metaLoadInFlightRef = useRef<string | null>(null);
   const isApplyingRouteQueryStateRef = useRef(false);
   const importAgentsInputRef = useRef<HTMLInputElement | null>(null);
   const importReviewBundleInputRef = useRef<HTMLInputElement | null>(null);
@@ -386,20 +397,26 @@ function HomePageContent() {
   }, [agentImportConflictPolicy]);
 
   useEffect(() => {
-    if (!selectedVersionId) return;
-    const interval = setInterval(() => {
-      void loadComments(selectedVersionId, true, selectedReviewJobId);
-    }, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [selectedVersionId, selectedReviewJobId]);
+    selectedVersionIdRef.current = selectedVersionId;
+    selectionGenerationRef.current += 1;
+  }, [selectedVersionId]);
 
   useEffect(() => {
-    if (!selectedVersionId) return;
+    selectedReviewJobIdRef.current = selectedReviewJobId;
+  }, [selectedReviewJobId]);
+
+  useEffect(() => {
+    // Single run-once poller reads from refs so fast doc-switches do not
+    // leave ghost intervals bound to stale (versionId, reviewJobId) values.
     const interval = setInterval(() => {
-      void loadReviewJobsSnapshot(selectedVersionId);
+      const vid = selectedVersionIdRef.current;
+      if (!vid) return;
+      const jid = selectedReviewJobIdRef.current;
+      void loadComments(vid, true, jid);
+      void loadReviewJobsSnapshot(vid);
     }, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [selectedVersionId, selectedReviewJobId]);
+  }, []);
 
   useEffect(() => {
     setMetaReviewRun(null);
@@ -419,9 +436,19 @@ function HomePageContent() {
   useEffect(() => {
     if (commentViewMode !== 'meta') return;
     if (!selectedVersionId) return;
+    // Key includes everything that meaningfully changes a meta-load outcome.
+    // Polling can rebuild reviewJobs on every tick, but if (version, job,
+    // status) is unchanged we must not fire a duplicate request in flight.
+    const key = `${selectedVersionId}:${selectedReviewJobId ?? 'none'}:${selectedReviewJob?.status ?? 'na'}:${commentModeSelectionSource}`;
+    if (metaLoadInFlightRef.current === key) return;
+    metaLoadInFlightRef.current = key;
     void loadOrCreateMetaReview(selectedVersionId, selectedReviewJobId, false, {
       fallbackToIndividualOnMissing: commentModeSelectionSource === 'auto',
       reviewJobStatus: selectedReviewJob?.status ?? null
+    }).finally(() => {
+      if (metaLoadInFlightRef.current === key) {
+        metaLoadInFlightRef.current = null;
+      }
     });
   }, [
     commentViewMode,
@@ -826,9 +853,14 @@ function HomePageContent() {
     jobs: ReviewJobRead[];
     selectedId: number | null;
   }> {
-    const currentSelected = selectedReviewJobId;
+    const generationAtCall = selectionGenerationRef.current;
+    const currentSelected = selectedReviewJobIdRef.current;
     try {
       const jobs = await apiFetch<ReviewJobRead[]>(`/review-jobs?document_version_id=${versionId}`);
+      // Drop the response if the user has switched documents in the meantime.
+      if (selectionGenerationRef.current !== generationAtCall) {
+        return { jobs: [], selectedId: currentSelected };
+      }
       setReviewJobs(jobs);
       if (jobs.length === 0) {
         setSelectedReviewJobId(null);
@@ -901,9 +933,14 @@ function HomePageContent() {
     markRecent: boolean,
     reviewJobId?: number | null
   ): Promise<CommentRead[]> {
+    const generationAtCall = selectionGenerationRef.current;
     try {
       const query = reviewJobId ? `&review_job_id=${reviewJobId}` : '';
       const data = await apiFetch<CommentRead[]>(`/comments?document_version_id=${versionId}${query}`);
+      // Drop stale response if the user has switched documents.
+      if (selectionGenerationRef.current !== generationAtCall) {
+        return commentsRef.current;
+      }
       const signature = buildCommentSignature(data);
       if (markRecent) {
         const now = Date.now();


### PR DESCRIPTION
## Summary

Three small, independent correctness fixes bundled as **P0 — bleed-stop** from the ownership review. Each has test coverage; none is a refactor. P1 (frontend split), P2 (Adjudicator/verdict), P3 (streaming), and P4 (hardening) ship as separate PRs.

### 1. Cross-document review mixup (the one you flagged)

Repro: delete a document, upload a new one, the new doc inherits the deleted doc's git history and sometimes comments from an in-flight review. Root cause chain:

- SQLite plain `INTEGER PRIMARY KEY` reuses rowids after DELETE — a new doc could claim a previous doc's id.
- `crud.delete_document` did not remove the git-backed `doc-<id>/` directory — stale history persisted on disk.
- Worker only validated the version existed; not the parent document — in-flight jobs for a just-deleted doc would write comments that a reused id could then claim.

Fixes (defense in depth):
- `sqlite_autoincrement=True` on `Document`, `DocumentVersion`, `ReviewJob` — new installs never reuse ids.
- New `remove_repo()` in `reviews/git_repo.py` (path-traversal guarded). `delete_document` calls it; `create_document` scrubs any stale repo at the target path (covers legacy DBs that already reused ids).
- Worker aborts before writing comments if the parent document has been deleted between enqueue and dequeue — logs `review_job_aborted_parent_missing`.
- `create_version` now commits the DB row before writing to git (no orphan history if DB fails).
- New regression test: `test_delete_document_removes_git_repo_and_prevents_id_reuse`.

### 2. Frontend polling races

Two `setInterval` effects in `frontend/app/page.tsx` captured `selectedVersionId`/`selectedReviewJobId` in closures. On rapid doc-switch, cleanup + recreate left ghost intervals polling the previous doc; out-of-order responses overwrote fresh state.

- Consolidated into a single run-once poller that reads from refs.
- Added a `selectionGenerationRef` counter — async responses drop themselves if the user has since switched documents.
- Meta auto-load effect now dedupes via an in-flight key, so polling-driven status transitions do not fire concurrent duplicate `/meta-reviews` requests.

### 3. Security defaults

- `OIDC_ALLOW_LOCAL_HEADER_FALLBACK` default **True → False**. A misconfigured proxy (trusting `X-Forwarded-For` from arbitrary sources) would have re-opened header auth.
- New `BodySizeLimitMiddleware` enforces `MAX_REQUEST_BODY_BYTES=5MB` via Content-Length fast-path. Closes `L4: No Input Size Limits` from SECURITY_AUDIT.md.

## Out of scope (coming in P1–P4)

- Frontend split of the 5,406-line `page.tsx` — P1.
- The existing meta-verdict (PR #107) appears to cover part of the proposed Adjudicator scope; P2 will audit and refine, not rebuild.
- Streaming review (SSE + LLM streaming + async meta job) — P3.
- CI `pip audit` / `npm audit` — P4. Note: GitHub flagged 22 dependabot alerts (6 high, 14 moderate) on main; these will be triaged in P4.

## Test plan

- [x] Backend `uv run --extra test pytest` — **104 passed**
- [x] Frontend `bun run test --run` — **43 passed**
- [x] Frontend `bun run build` — **passes**
- [x] New regression test for the mixup bug
- [x] New regression test for body size limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request body size limit enforcement (5 MiB default)

* **Bug Fixes**
  * Disabled OIDC local header fallback for enhanced security
  * Document deletion now properly removes repository files and prevents row ID reuse
  * Fixed race condition preventing stale comments from overwriting current document selection
  * Review job worker validates parent document existence before processing

* **Tests**
  * Added security tests for request body size limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->