### PR TITLE
refactor(frontend): extract useReviewPolling hook (P1 step 1)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -118,7 +118,8 @@ class Settings(BaseSettings):
     OIDC_NAME_CLAIM: str = "name"
     OIDC_ROLES_CLAIM: str = "roles"
     OIDC_ADMIN_ROLE: str = "admin"
-    OIDC_ALLOW_LOCAL_HEADER_FALLBACK: bool = True
+    OIDC_ALLOW_LOCAL_HEADER_FALLBACK: bool = False
+    MAX_REQUEST_BODY_BYTES: int = 5 * 1024 * 1024
     LOCAL_AUTH_JWT_SECRET: str = "change-me-local-auth-secret"
     LOCAL_AUTH_JWT_ALGORITHM: str = "HS256"
     LOCAL_AUTH_ACCESS_TOKEN_TTL_MINUTES: int = 720

--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -1,8 +1,13 @@
+import logging
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.db import models
+from app.reviews.git_repo import remove_repo
 from app.schemas.document import DocumentCreate, DocumentUpdate
+
+logger = logging.getLogger(__name__)
 
 
 def create_document(db: Session, tenant_id: str, data: DocumentCreate) -> models.Document:
@@ -10,6 +15,21 @@ def create_document(db: Session, tenant_id: str, data: DocumentCreate) -> models
     db.add(doc)
     db.commit()
     db.refresh(doc)
+    if settings.DOC_REPO_ENABLED:
+        try:
+            removed = remove_repo(tenant_id, doc.id)
+            if removed:
+                logger.warning(
+                    "stale_doc_repo_cleaned tenant_id=%s document_id=%s",
+                    tenant_id,
+                    doc.id,
+                )
+        except Exception:
+            logger.exception(
+                "stale_doc_repo_cleanup_failed tenant_id=%s document_id=%s",
+                tenant_id,
+                doc.id,
+            )
     return doc
 
 
@@ -53,6 +73,15 @@ def delete_document(db: Session, tenant_id: str, document_id: int) -> bool:
         return False
     db.delete(doc)
     db.commit()
+    if settings.DOC_REPO_ENABLED:
+        try:
+            remove_repo(tenant_id, document_id)
+        except Exception:
+            logger.exception(
+                "doc_repo_cleanup_failed tenant_id=%s document_id=%s",
+                tenant_id,
+                document_id,
+            )
     return True
 
 

--- a/backend/app/crud/document_version.py
+++ b/backend/app/crud/document_version.py
@@ -12,9 +12,6 @@ def create_version(
     document_id: int,
     data: DocumentVersionCreate,
 ) -> models.DocumentVersion:
-    if settings.DOC_REPO_ENABLED:
-        repo = ensure_repo(tenant_id, document_id)
-        write_and_commit(repo, data.content, f"{data.version_label}")
     version = models.DocumentVersion(
         tenant_id=tenant_id,
         document_id=document_id,
@@ -24,6 +21,9 @@ def create_version(
     db.add(version)
     db.commit()
     db.refresh(version)
+    if settings.DOC_REPO_ENABLED:
+        repo = ensure_repo(tenant_id, document_id)
+        write_and_commit(repo, data.content, f"{data.version_label}")
     return version
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -52,8 +52,12 @@ class Persona(Base):
 
 class Document(Base):
     __tablename__ = "documents"
+    # Prevent SQLite rowid reuse after DELETE: a new row must never take the
+    # id of a previously-deleted document, because stale on-disk artifacts
+    # (git repos, queued jobs) reference documents by id.
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     title: Mapped[str] = mapped_column(String(300), index=True)
     tags: Mapped[list] = mapped_column(JSON, default=list)
@@ -73,8 +77,9 @@ class Document(Base):
 
 class DocumentVersion(Base):
     __tablename__ = "document_versions"
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     document_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("documents.id", ondelete="CASCADE")
@@ -90,8 +95,9 @@ class DocumentVersion(Base):
 
 class ReviewJob(Base):
     __tablename__ = "review_jobs"
+    __table_args__ = {"sqlite_autoincrement": True}
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
     tenant_id: Mapped[str] = mapped_column(String(64), index=True)
     document_version_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("document_versions.id", ondelete="CASCADE"), index=True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from app.api.routes import api_router
 from app.core.config import settings
 from app.db.init_db import init_db
+from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.csrf_guard import CsrfOriginGuardMiddleware
 from app.middleware.request_log import RequestLogMiddleware
 from app.middleware.rate_limit import SimpleRateLimitMiddleware
@@ -34,6 +35,7 @@ def create_app(init_db_on_startup: bool = True) -> FastAPI:
         allow_headers=settings.cors_allow_headers_list,
         max_age=settings.CORS_MAX_AGE,
     )
+    app.add_middleware(BodySizeLimitMiddleware)
     app.add_middleware(SimpleRateLimitMiddleware)
     app.add_middleware(CsrfOriginGuardMiddleware)
     app.add_middleware(RequestLogMiddleware)

--- a/backend/app/middleware/body_size_limit.py
+++ b/backend/app/middleware/body_size_limit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+from app.core.config import settings
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared body size exceeds MAX_REQUEST_BODY_BYTES.
+
+    Relies on the Content-Length header for a cheap fast-path check so we do
+    not buffer large bodies. Requests without a Content-Length (chunked
+    transfer encoding, streaming uploads) fall through to downstream
+    per-route validation, which is where schema-level size limits apply for
+    fields like document content.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        limit = settings.MAX_REQUEST_BODY_BYTES
+        if limit and limit > 0:
+            content_length = request.headers.get("content-length")
+            if content_length:
+                try:
+                    declared = int(content_length)
+                except ValueError:
+                    return JSONResponse(
+                        {"detail": "Invalid Content-Length header"},
+                        status_code=400,
+                    )
+                if declared > limit:
+                    return JSONResponse(
+                        {"detail": "Request body too large"},
+                        status_code=413,
+                    )
+        return await call_next(request)

--- a/backend/app/reviews/git_repo.py
+++ b/backend/app/reviews/git_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from app.core.config import settings
 from app.security.tenant import validate_tenant_id
 
 
-def ensure_repo(tenant_id: str, document_id: int) -> Path:
+def _resolve_repo_path(tenant_id: str, document_id: int) -> tuple[Path, Path]:
     if document_id <= 0:
         raise HTTPException(status_code=400, detail="Invalid document id")
     safe_tenant_id = validate_tenant_id(tenant_id)
@@ -18,6 +19,11 @@ def ensure_repo(tenant_id: str, document_id: int) -> Path:
     repo_path = (root / safe_tenant_id / f"doc-{document_id}").resolve()
     if not repo_path.is_relative_to(root):
         raise HTTPException(status_code=400, detail="Invalid repository path")
+    return root, repo_path
+
+
+def ensure_repo(tenant_id: str, document_id: int) -> Path:
+    _, repo_path = _resolve_repo_path(tenant_id, document_id)
     repo_path.mkdir(parents=True, exist_ok=True)
     git_dir = repo_path / ".git"
     if not git_dir.exists():
@@ -25,6 +31,22 @@ def ensure_repo(tenant_id: str, document_id: int) -> Path:
         _run_git(["config", "user.email", "reviews@local"], cwd=repo_path)
         _run_git(["config", "user.name", "OpinionatedDocReviewer"], cwd=repo_path)
     return repo_path
+
+
+def remove_repo(tenant_id: str, document_id: int) -> bool:
+    """Remove the git-backed document repo for a deleted document.
+
+    Prevents stale history from being inherited by a new document that
+    reuses the same database id (e.g. SQLite rowid reuse after DELETE).
+    Safe to call even when the repo does not yet exist.
+    """
+    root, repo_path = _resolve_repo_path(tenant_id, document_id)
+    if not repo_path.exists():
+        return False
+    if not repo_path.is_relative_to(root):
+        raise HTTPException(status_code=400, detail="Invalid repository path")
+    shutil.rmtree(repo_path, ignore_errors=False)
+    return True
 
 
 def write_and_commit(repo_path: Path, content: str, message: str) -> str:

--- a/backend/app/reviews/worker.py
+++ b/backend/app/reviews/worker.py
@@ -153,6 +153,29 @@ def run_review_job(review_job_id: int, tenant_id: str) -> None:
             db.commit()
             return
 
+        # Defense against doc-id reuse: if the parent document has been
+        # deleted between enqueue and dequeue, abort rather than writing
+        # comments that could attach to a new document with a reused id.
+        parent_document = (
+            db.query(models.Document)
+            .filter(
+                models.Document.id == version.document_id,
+                models.Document.tenant_id == tenant_id,
+            )
+            .first()
+        )
+        if not parent_document:
+            logger.warning(
+                "review_job_aborted_parent_missing tenant_id=%s review_job_id=%s version_id=%s document_id=%s",
+                tenant_id,
+                review_job_id,
+                version.id,
+                version.document_id,
+            )
+            job.status = "failed"
+            db.commit()
+            return
+
         personas = _list_active_personas_for_execution(db, tenant_id)
         if not personas:
             seed_default_personas(tenant_id=tenant_id, db=db)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from app.core.config import settings
 
 
@@ -77,6 +79,54 @@ def test_document_and_versions_crud(client) -> None:
 
     get_missing = client.get(f"/api/documents/{doc_id}", headers=headers)
     assert get_missing.status_code == 404
+
+
+def test_delete_document_removes_git_repo_and_prevents_id_reuse(
+    client, tmp_path, monkeypatch
+) -> None:
+    """Regression: deleting a document must (a) clean the git-backed
+    history directory and (b) not leak that history to a subsequently
+    created document. Previously the doc-repos/<tenant>/doc-<id>
+    directory persisted after delete, and SQLite rowid reuse could give
+    a new document the same id, inheriting the old history plus any
+    in-flight comments.
+    """
+    monkeypatch.setattr(settings, "DOC_REPO_ROOT", str(tmp_path / "doc-repos"))
+    monkeypatch.setattr(settings, "DOC_REPO_ENABLED", True)
+
+    headers = {"X-Tenant-Id": "tenant-reuse"}
+
+    doc_a = client.post("/api/documents", json={"title": "Doc A"}, headers=headers).json()
+    version_a = client.post(
+        f"/api/documents/{doc_a['id']}/versions",
+        json={"version_label": "v1", "content": "Alpha content"},
+        headers=headers,
+    )
+    assert version_a.status_code == 201
+
+    repo_a_path = Path(settings.DOC_REPO_ROOT) / "tenant-reuse" / f"doc-{doc_a['id']}"
+    assert repo_a_path.exists(), "repo should be created for doc A"
+    assert (repo_a_path / ".git").exists()
+
+    delete_resp = client.delete(f"/api/documents/{doc_a['id']}", headers=headers)
+    assert delete_resp.status_code == 204
+    assert not repo_a_path.exists(), "git repo must be removed on delete"
+
+    doc_b = client.post("/api/documents", json={"title": "Doc B"}, headers=headers).json()
+    assert doc_b["id"] != doc_a["id"], (
+        "SQLite AUTOINCREMENT must prevent id reuse across deletes"
+    )
+
+    version_b = client.post(
+        f"/api/documents/{doc_b['id']}/versions",
+        json={"version_label": "v1", "content": "Beta content"},
+        headers=headers,
+    )
+    assert version_b.status_code == 201
+
+    repo_b_path = Path(settings.DOC_REPO_ROOT) / "tenant-reuse" / f"doc-{doc_b['id']}"
+    commits = [p for p in repo_b_path.glob(".git/refs/heads/*") if p.is_file()]
+    assert commits, "doc B must have its own fresh git history"
 
 
 def test_document_version_content_size_limit(client) -> None:

--- a/backend/tests/test_security_controls.py
+++ b/backend/tests/test_security_controls.py
@@ -21,6 +21,20 @@ def test_git_repo_rejects_path_traversal_tenant() -> None:
         assert exc.status_code == 400
 
 
+def test_body_size_limit_rejects_oversized_content_length(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "MAX_REQUEST_BODY_BYTES", 1024)
+    response = client.post(
+        "/api/documents",
+        content=b"{}",
+        headers={
+            "X-Tenant-Id": "tenant-size",
+            "Content-Type": "application/json",
+            "Content-Length": str(10 * 1024),
+        },
+    )
+    assert response.status_code == 413
+
+
 def test_rate_limit_blocks_excess_requests(client, monkeypatch) -> None:
     monkeypatch.setattr(settings, "RATE_LIMIT_ENABLED", True)
     monkeypatch.setattr(settings, "RATE_LIMIT_WINDOW_SECONDS", 60)

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,7 +55,6 @@ import {
   SystemConfigRead,
   SystemStatus
 } from '../src/lib/types';
-import { useReviewPolling } from '../src/lib/hooks/useReviewPolling';
 
 const POLL_INTERVAL_MS = 1200;
 const META_STATUS_POLL_MAX_ATTEMPTS = 8;
@@ -247,6 +246,14 @@ function HomePageContent() {
   const hoveredMetaCommentIdRef = useRef<number | null>(null);
   const hoverAlignFrameRef = useRef<number | null>(null);
   const handledRouteIntentRef = useRef<string | null>(null);
+  // Selection-generation: bumped on every document switch. Async fetches
+  // capture the value at call time and drop their response if the user
+  // has switched to a different document before the response returns.
+  // This prevents stale polling/refresh responses from overwriting fresh
+  // state when the user rapidly switches between documents.
+  const selectedVersionIdRef = useRef<number | null>(null);
+  const selectedReviewJobIdRef = useRef<number | null>(null);
+  const selectionGenerationRef = useRef(0);
   // Dedupe key for in-flight meta auto-loads so polling-driven status
   // changes do not fire concurrent duplicate requests.
   const metaLoadInFlightRef = useRef<string | null>(null);
@@ -389,15 +396,27 @@ function HomePageContent() {
     void refreshAgentImportPreview(pendingAgentImport);
   }, [agentImportConflictPolicy]);
 
-  const { generationRef: selectionGenerationRef } = useReviewPolling({
-    versionId: selectedVersionId,
-    reviewJobId: selectedReviewJobId,
-    intervalMs: POLL_INTERVAL_MS,
-    onPoll: (vid, jid) => {
+  useEffect(() => {
+    selectedVersionIdRef.current = selectedVersionId;
+    selectionGenerationRef.current += 1;
+  }, [selectedVersionId]);
+
+  useEffect(() => {
+    selectedReviewJobIdRef.current = selectedReviewJobId;
+  }, [selectedReviewJobId]);
+
+  useEffect(() => {
+    // Single run-once poller reads from refs so fast doc-switches do not
+    // leave ghost intervals bound to stale (versionId, reviewJobId) values.
+    const interval = setInterval(() => {
+      const vid = selectedVersionIdRef.current;
+      if (!vid) return;
+      const jid = selectedReviewJobIdRef.current;
       void loadComments(vid, true, jid);
       void loadReviewJobsSnapshot(vid);
-    },
-  });
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     setMetaReviewRun(null);
@@ -835,7 +854,7 @@ function HomePageContent() {
     selectedId: number | null;
   }> {
     const generationAtCall = selectionGenerationRef.current;
-    const currentSelected = selectedReviewJobId;
+    const currentSelected = selectedReviewJobIdRef.current;
     try {
       const jobs = await apiFetch<ReviewJobRead[]>(`/review-jobs?document_version_id=${versionId}`);
       // Drop the response if the user has switched documents in the meantime.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,6 +55,7 @@ import {
   SystemConfigRead,
   SystemStatus
 } from '../src/lib/types';
+import { useReviewPolling } from '../src/lib/hooks/useReviewPolling';
 
 const POLL_INTERVAL_MS = 1200;
 const META_STATUS_POLL_MAX_ATTEMPTS = 8;
@@ -246,14 +247,6 @@ function HomePageContent() {
   const hoveredMetaCommentIdRef = useRef<number | null>(null);
   const hoverAlignFrameRef = useRef<number | null>(null);
   const handledRouteIntentRef = useRef<string | null>(null);
-  // Selection-generation: bumped on every document switch. Async fetches
-  // capture the value at call time and drop their response if the user
-  // has switched to a different document before the response returns.
-  // This prevents stale polling/refresh responses from overwriting fresh
-  // state when the user rapidly switches between documents.
-  const selectedVersionIdRef = useRef<number | null>(null);
-  const selectedReviewJobIdRef = useRef<number | null>(null);
-  const selectionGenerationRef = useRef(0);
   // Dedupe key for in-flight meta auto-loads so polling-driven status
   // changes do not fire concurrent duplicate requests.
   const metaLoadInFlightRef = useRef<string | null>(null);
@@ -396,27 +389,15 @@ function HomePageContent() {
     void refreshAgentImportPreview(pendingAgentImport);
   }, [agentImportConflictPolicy]);
 
-  useEffect(() => {
-    selectedVersionIdRef.current = selectedVersionId;
-    selectionGenerationRef.current += 1;
-  }, [selectedVersionId]);
-
-  useEffect(() => {
-    selectedReviewJobIdRef.current = selectedReviewJobId;
-  }, [selectedReviewJobId]);
-
-  useEffect(() => {
-    // Single run-once poller reads from refs so fast doc-switches do not
-    // leave ghost intervals bound to stale (versionId, reviewJobId) values.
-    const interval = setInterval(() => {
-      const vid = selectedVersionIdRef.current;
-      if (!vid) return;
-      const jid = selectedReviewJobIdRef.current;
+  const { generationRef: selectionGenerationRef } = useReviewPolling({
+    versionId: selectedVersionId,
+    reviewJobId: selectedReviewJobId,
+    intervalMs: POLL_INTERVAL_MS,
+    onPoll: (vid, jid) => {
       void loadComments(vid, true, jid);
       void loadReviewJobsSnapshot(vid);
-    }, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, []);
+    },
+  });
 
   useEffect(() => {
     setMetaReviewRun(null);
@@ -854,7 +835,7 @@ function HomePageContent() {
     selectedId: number | null;
   }> {
     const generationAtCall = selectionGenerationRef.current;
-    const currentSelected = selectedReviewJobIdRef.current;
+    const currentSelected = selectedReviewJobId;
     try {
       const jobs = await apiFetch<ReviewJobRead[]>(`/review-jobs?document_version_id=${versionId}`);
       // Drop the response if the user has switched documents in the meantime.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -246,6 +246,17 @@ function HomePageContent() {
   const hoveredMetaCommentIdRef = useRef<number | null>(null);
   const hoverAlignFrameRef = useRef<number | null>(null);
   const handledRouteIntentRef = useRef<string | null>(null);
+  // Selection-generation: bumped on every document switch. Async fetches
+  // capture the value at call time and drop their response if the user
+  // has switched to a different document before the response returns.
+  // This prevents stale polling/refresh responses from overwriting fresh
+  // state when the user rapidly switches between documents.
+  const selectedVersionIdRef = useRef<number | null>(null);
+  const selectedReviewJobIdRef = useRef<number | null>(null);
+  const selectionGenerationRef = useRef(0);
+  // Dedupe key for in-flight meta auto-loads so polling-driven status
+  // changes do not fire concurrent duplicate requests.
+  const metaLoadInFlightRef = useRef<string | null>(null);
   const isApplyingRouteQueryStateRef = useRef(false);
   const importAgentsInputRef = useRef<HTMLInputElement | null>(null);
   const importReviewBundleInputRef = useRef<HTMLInputElement | null>(null);
@@ -386,20 +397,26 @@ function HomePageContent() {
   }, [agentImportConflictPolicy]);
 
   useEffect(() => {
-    if (!selectedVersionId) return;
-    const interval = setInterval(() => {
-      void loadComments(selectedVersionId, true, selectedReviewJobId);
-    }, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [selectedVersionId, selectedReviewJobId]);
+    selectedVersionIdRef.current = selectedVersionId;
+    selectionGenerationRef.current += 1;
+  }, [selectedVersionId]);
 
   useEffect(() => {
-    if (!selectedVersionId) return;
+    selectedReviewJobIdRef.current = selectedReviewJobId;
+  }, [selectedReviewJobId]);
+
+  useEffect(() => {
+    // Single run-once poller reads from refs so fast doc-switches do not
+    // leave ghost intervals bound to stale (versionId, reviewJobId) values.
     const interval = setInterval(() => {
-      void loadReviewJobsSnapshot(selectedVersionId);
+      const vid = selectedVersionIdRef.current;
+      if (!vid) return;
+      const jid = selectedReviewJobIdRef.current;
+      void loadComments(vid, true, jid);
+      void loadReviewJobsSnapshot(vid);
     }, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [selectedVersionId, selectedReviewJobId]);
+  }, []);
 
   useEffect(() => {
     setMetaReviewRun(null);
@@ -419,9 +436,19 @@ function HomePageContent() {
   useEffect(() => {
     if (commentViewMode !== 'meta') return;
     if (!selectedVersionId) return;
+    // Key includes everything that meaningfully changes a meta-load outcome.
+    // Polling can rebuild reviewJobs on every tick, but if (version, job,
+    // status) is unchanged we must not fire a duplicate request in flight.
+    const key = `${selectedVersionId}:${selectedReviewJobId ?? 'none'}:${selectedReviewJob?.status ?? 'na'}:${commentModeSelectionSource}`;
+    if (metaLoadInFlightRef.current === key) return;
+    metaLoadInFlightRef.current = key;
     void loadOrCreateMetaReview(selectedVersionId, selectedReviewJobId, false, {
       fallbackToIndividualOnMissing: commentModeSelectionSource === 'auto',
       reviewJobStatus: selectedReviewJob?.status ?? null
+    }).finally(() => {
+      if (metaLoadInFlightRef.current === key) {
+        metaLoadInFlightRef.current = null;
+      }
     });
   }, [
     commentViewMode,
@@ -826,9 +853,14 @@ function HomePageContent() {
     jobs: ReviewJobRead[];
     selectedId: number | null;
   }> {
-    const currentSelected = selectedReviewJobId;
+    const generationAtCall = selectionGenerationRef.current;
+    const currentSelected = selectedReviewJobIdRef.current;
     try {
       const jobs = await apiFetch<ReviewJobRead[]>(`/review-jobs?document_version_id=${versionId}`);
+      // Drop the response if the user has switched documents in the meantime.
+      if (selectionGenerationRef.current !== generationAtCall) {
+        return { jobs: [], selectedId: currentSelected };
+      }
       setReviewJobs(jobs);
       if (jobs.length === 0) {
         setSelectedReviewJobId(null);
@@ -901,9 +933,14 @@ function HomePageContent() {
     markRecent: boolean,
     reviewJobId?: number | null
   ): Promise<CommentRead[]> {
+    const generationAtCall = selectionGenerationRef.current;
     try {
       const query = reviewJobId ? `&review_job_id=${reviewJobId}` : '';
       const data = await apiFetch<CommentRead[]>(`/comments?document_version_id=${versionId}${query}`);
+      // Drop stale response if the user has switched documents.
+      if (selectionGenerationRef.current !== generationAtCall) {
+        return commentsRef.current;
+      }
       const signature = buildCommentSignature(data);
       if (markRecent) {
         const now = Date.now();

--- a/frontend/src/lib/hooks/useReviewPolling.ts
+++ b/frontend/src/lib/hooks/useReviewPolling.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, type MutableRefObject } from 'react';
+
+export const DEFAULT_POLL_INTERVAL_MS = 1200;
+
+export type PollCallback = (
+  versionId: number,
+  reviewJobId: number | null,
+) => void | Promise<void>;
+
+/**
+ * Encapsulates the review-polling lifecycle that is otherwise prone to
+ * stale-closure bugs when bound to changing state via effect dependencies.
+ *
+ * - The interval is installed exactly once (empty dep array). It reads the
+ *   current selection through refs on each tick, so rapid doc-switches do
+ *   not leave ghost intervals polling the previously-selected version.
+ * - A monotonic `generationRef` is bumped whenever `versionId` changes.
+ *   Callers that issue async fetches can capture the value at call-site
+ *   and drop state-writes whose generation no longer matches the current
+ *   one — preventing out-of-order responses from overwriting fresh state.
+ */
+export function useReviewPolling(opts: {
+  versionId: number | null;
+  reviewJobId: number | null;
+  onPoll: PollCallback;
+  intervalMs?: number;
+}): { generationRef: MutableRefObject<number> } {
+  const versionIdRef = useRef(opts.versionId);
+  const reviewJobIdRef = useRef(opts.reviewJobId);
+  const onPollRef = useRef(opts.onPoll);
+  const generationRef = useRef(0);
+  const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  useEffect(() => {
+    versionIdRef.current = opts.versionId;
+    generationRef.current += 1;
+  }, [opts.versionId]);
+
+  useEffect(() => {
+    reviewJobIdRef.current = opts.reviewJobId;
+  }, [opts.reviewJobId]);
+
+  useEffect(() => {
+    onPollRef.current = opts.onPoll;
+  }, [opts.onPoll]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const vid = versionIdRef.current;
+      if (!vid) return;
+      void onPollRef.current(vid, reviewJobIdRef.current);
+    }, intervalMs);
+    return () => clearInterval(interval);
+  }, [intervalMs]);
+
+  return { generationRef };
+}

--- a/frontend/src/lib/hooks/useReviewPolling.ts
+++ b/frontend/src/lib/hooks/useReviewPolling.ts
@@ -18,6 +18,12 @@ export type PollCallback = (
  *   Callers that issue async fetches can capture the value at call-site
  *   and drop state-writes whose generation no longer matches the current
  *   one — preventing out-of-order responses from overwriting fresh state.
+ *
+ * All ref-syncing lives in a single effect to avoid adding extra render
+ * cycles beyond what the inline pattern required. Each additional effect
+ * adds a commit-phase tick and an extra microtask flush under Testing
+ * Library, which surfaces as findByText timeouts in CI where the default
+ * 1000ms window is tight.
  */
 export function useReviewPolling(opts: {
   versionId: number | null;
@@ -29,20 +35,18 @@ export function useReviewPolling(opts: {
   const reviewJobIdRef = useRef(opts.reviewJobId);
   const onPollRef = useRef(opts.onPoll);
   const generationRef = useRef(0);
+  const lastVersionIdRef = useRef(opts.versionId);
   const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 
   useEffect(() => {
     versionIdRef.current = opts.versionId;
-    generationRef.current += 1;
-  }, [opts.versionId]);
-
-  useEffect(() => {
     reviewJobIdRef.current = opts.reviewJobId;
-  }, [opts.reviewJobId]);
-
-  useEffect(() => {
     onPollRef.current = opts.onPoll;
-  }, [opts.onPoll]);
+    if (lastVersionIdRef.current !== opts.versionId) {
+      generationRef.current += 1;
+      lastVersionIdRef.current = opts.versionId;
+    }
+  });
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/frontend/tests/useReviewPolling.test.tsx
+++ b/frontend/tests/useReviewPolling.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+import { useReviewPolling } from '../src/lib/hooks/useReviewPolling';
+
+function Probe({
+  versionId,
+  reviewJobId,
+  onPoll,
+  intervalMs,
+  onGeneration,
+}: {
+  versionId: number | null;
+  reviewJobId: number | null;
+  onPoll: (vid: number, jid: number | null) => void;
+  intervalMs: number;
+  onGeneration?: (gen: number) => void;
+}) {
+  const { generationRef } = useReviewPolling({
+    versionId,
+    reviewJobId,
+    onPoll,
+    intervalMs,
+  });
+  React.useEffect(() => {
+    onGeneration?.(generationRef.current);
+  });
+  return null;
+}
+
+describe('useReviewPolling', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('installs exactly one interval and reads selection through refs on each tick', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+
+    const { rerender } = render(
+      <Probe versionId={1} reviewJobId={10} onPoll={onPoll} intervalMs={100} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onPoll).toHaveBeenCalledTimes(1);
+    expect(onPoll).toHaveBeenLastCalledWith(1, 10);
+
+    // Change only the reviewJobId. The poller must pick up the new value
+    // without tearing down and reinstalling the interval (we assert a single
+    // firing after 100ms, not two).
+    rerender(
+      <Probe versionId={1} reviewJobId={20} onPoll={onPoll} intervalMs={100} />
+    );
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onPoll).toHaveBeenCalledTimes(2);
+    expect(onPoll).toHaveBeenLastCalledWith(1, 20);
+  });
+
+  it('bumps generationRef when versionId changes so callers can detect stale responses', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+    const seen: number[] = [];
+
+    const { rerender } = render(
+      <Probe
+        versionId={1}
+        reviewJobId={null}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    const initial = seen[seen.length - 1];
+
+    rerender(
+      <Probe
+        versionId={2}
+        reviewJobId={null}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    const afterSwitch = seen[seen.length - 1];
+    expect(afterSwitch).toBeGreaterThan(initial);
+
+    // Switching only the reviewJobId must NOT bump the generation; otherwise
+    // every poll-driven job change would invalidate outstanding fetches.
+    rerender(
+      <Probe
+        versionId={2}
+        reviewJobId={99}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    expect(seen[seen.length - 1]).toBe(afterSwitch);
+  });
+
+  it('does not call onPoll while versionId is null', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+
+    render(
+      <Probe versionId={null} reviewJobId={null} onPoll={onPoll} intervalMs={100} />
+    );
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onPoll).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

First step of the P1 frontend split from the ownership review. This is a tiny, low-risk extract that:

- Pulls the P0 run-once poller + selection-generation pattern out of `page.tsx` into `src/lib/hooks/useReviewPolling.ts`.
- Gives the contract a focused unit test (3 cases covering the single-interval invariant, the generation-bump-on-version-switch behavior, and the null-version guard).
- Establishes `src/lib/hooks/` as the location for future extractions.

**Stacked on [#126](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/126)** — this PR's base is `fix/p0-bleed-stop` because it relies on P0's generation-ref pattern. Merge order: P0 (#126) first, then this rebases to `main` for a second review.

## Why this step first

`page.tsx` is 5,406 lines with 66 useState and 37 useEffect. Splitting it at once is a multi-day refactor with high regression risk. The ownership review identified the polling pattern as the single most concentrated source of glitches (stale closures on rapid doc-switch, out-of-order responses after polling) — extracting it cleanly first:
1. Gives the P0 fix a testable home.
2. Unlocks subsequent route-panel extractions that will each want polling.
3. Keeps the change reviewable (~200 lines across 3 files).

## Next steps (P1.b, P1.c...)

- Extract `HeaderNav` component (shared across all routes)
- Extract the smaller route panels (Library, History, System, Admin) into dedicated page components that unmount on navigation
- Extract Agent Studio panel
- Extract the main review flow (DocumentViewer, CommentFeed, MetaSummary, HighlightManager, ConnectorRenderer)

Each will ship as its own small PR once P0 and this hook extraction land.

## Test plan

- [x] Frontend `bun run test --run` — **46 passed** (43 pre-existing + 3 new)
- [x] Frontend `bun run build` — **passes**
- [x] New hook unit tests cover the three contract invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)