### PR TITLE
feat(frontend): add useReviewPolling hook + tests (P1.a)

### DIFF
--- a/frontend/src/lib/hooks/useReviewPolling.ts
+++ b/frontend/src/lib/hooks/useReviewPolling.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, type MutableRefObject } from 'react';
+
+export const DEFAULT_POLL_INTERVAL_MS = 1200;
+
+export type PollCallback = (
+  versionId: number,
+  reviewJobId: number | null,
+) => void | Promise<void>;
+
+/**
+ * Encapsulates the review-polling lifecycle that is otherwise prone to
+ * stale-closure bugs when bound to changing state via effect dependencies.
+ *
+ * - The interval is installed exactly once (empty dep array). It reads the
+ *   current selection through refs on each tick, so rapid doc-switches do
+ *   not leave ghost intervals polling the previously-selected version.
+ * - A monotonic `generationRef` is bumped whenever `versionId` changes.
+ *   Callers that issue async fetches can capture the value at call-site
+ *   and drop state-writes whose generation no longer matches the current
+ *   one — preventing out-of-order responses from overwriting fresh state.
+ *
+ * All ref-syncing lives in a single effect to avoid adding extra render
+ * cycles beyond what the inline pattern required. Each additional effect
+ * adds a commit-phase tick and an extra microtask flush under Testing
+ * Library, which surfaces as findByText timeouts in CI where the default
+ * 1000ms window is tight.
+ */
+export function useReviewPolling(opts: {
+  versionId: number | null;
+  reviewJobId: number | null;
+  onPoll: PollCallback;
+  intervalMs?: number;
+}): { generationRef: MutableRefObject<number> } {
+  const versionIdRef = useRef(opts.versionId);
+  const reviewJobIdRef = useRef(opts.reviewJobId);
+  const onPollRef = useRef(opts.onPoll);
+  const generationRef = useRef(0);
+  const lastVersionIdRef = useRef(opts.versionId);
+  const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  useEffect(() => {
+    versionIdRef.current = opts.versionId;
+    reviewJobIdRef.current = opts.reviewJobId;
+    onPollRef.current = opts.onPoll;
+    if (lastVersionIdRef.current !== opts.versionId) {
+      generationRef.current += 1;
+      lastVersionIdRef.current = opts.versionId;
+    }
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const vid = versionIdRef.current;
+      if (!vid) return;
+      void onPollRef.current(vid, reviewJobIdRef.current);
+    }, intervalMs);
+    return () => clearInterval(interval);
+  }, [intervalMs]);
+
+  return { generationRef };
+}

--- a/frontend/tests/useReviewPolling.test.tsx
+++ b/frontend/tests/useReviewPolling.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+import { useReviewPolling } from '../src/lib/hooks/useReviewPolling';
+
+function Probe({
+  versionId,
+  reviewJobId,
+  onPoll,
+  intervalMs,
+  onGeneration,
+}: {
+  versionId: number | null;
+  reviewJobId: number | null;
+  onPoll: (vid: number, jid: number | null) => void;
+  intervalMs: number;
+  onGeneration?: (gen: number) => void;
+}) {
+  const { generationRef } = useReviewPolling({
+    versionId,
+    reviewJobId,
+    onPoll,
+    intervalMs,
+  });
+  React.useEffect(() => {
+    onGeneration?.(generationRef.current);
+  });
+  return null;
+}
+
+describe('useReviewPolling', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('installs exactly one interval and reads selection through refs on each tick', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+
+    const { rerender } = render(
+      <Probe versionId={1} reviewJobId={10} onPoll={onPoll} intervalMs={100} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onPoll).toHaveBeenCalledTimes(1);
+    expect(onPoll).toHaveBeenLastCalledWith(1, 10);
+
+    // Change only the reviewJobId. The poller must pick up the new value
+    // without tearing down and reinstalling the interval (we assert a single
+    // firing after 100ms, not two).
+    rerender(
+      <Probe versionId={1} reviewJobId={20} onPoll={onPoll} intervalMs={100} />
+    );
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onPoll).toHaveBeenCalledTimes(2);
+    expect(onPoll).toHaveBeenLastCalledWith(1, 20);
+  });
+
+  it('bumps generationRef when versionId changes so callers can detect stale responses', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+    const seen: number[] = [];
+
+    const { rerender } = render(
+      <Probe
+        versionId={1}
+        reviewJobId={null}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    const initial = seen[seen.length - 1];
+
+    rerender(
+      <Probe
+        versionId={2}
+        reviewJobId={null}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    const afterSwitch = seen[seen.length - 1];
+    expect(afterSwitch).toBeGreaterThan(initial);
+
+    // Switching only the reviewJobId must NOT bump the generation; otherwise
+    // every poll-driven job change would invalidate outstanding fetches.
+    rerender(
+      <Probe
+        versionId={2}
+        reviewJobId={99}
+        onPoll={onPoll}
+        intervalMs={100}
+        onGeneration={(gen) => seen.push(gen)}
+      />
+    );
+    expect(seen[seen.length - 1]).toBe(afterSwitch);
+  });
+
+  it('does not call onPoll while versionId is null', () => {
+    vi.useFakeTimers();
+    const onPoll = vi.fn();
+
+    render(
+      <Probe versionId={null} reviewJobId={null} onPoll={onPoll} intervalMs={100} />
+    );
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onPoll).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a self-contained hook at \`src/lib/hooks/useReviewPolling.ts\` that encodes the run-once polling contract from [P0 (#126)](https://github.com/jonzobrist/OpinionatedDocReviewer/pull/126): single interval, refs-based reads on each tick, monotonic generation counter bumped on version switches so async fetches can drop stale responses.

## Wiring status

Intentionally left **unwired from page.tsx** for now. An earlier attempt to wire it in introduced a ~70ms commit-phase delta that surfaced as \`findByText\` flakes in CI. Rather than ship a known-risky change mid-P1, the hook lands as library code and gets wired in during the frontend split (P1.b/c/d) where the surrounding effect cascade can be reasoned about locally.

## What this PR unblocks

- \`src/lib/hooks/\` established as the home for future hook extractions.
- A reference implementation future route-panel components can import.

## Test plan

- [x] 3 new unit tests pin the hook contract (single-interval invariant, generation-bump-on-version-switch, null-version guard).
- [x] Frontend \`bun run test --run\` — **46/46 passed** (43 existing + 3 new).
- [x] Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)