### PR TITLE
refactor(frontend): extract MermaidDiagram component (P1.b)

### DIFF
--- a/frontend/app/components/MermaidDiagram.tsx
+++ b/frontend/app/components/MermaidDiagram.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export function MermaidDiagram({ chart }: { chart: string }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const chartIdRef = useRef(`mermaid-${Math.random().toString(36).slice(2)}`);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    const run = async () => {
+      const target = containerRef.current;
+      if (!target) return;
+      try {
+        const mod = await import('mermaid');
+        const mermaid = mod.default;
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: 'strict',
+          theme: 'neutral',
+          suppressErrorRendering: true
+        });
+        const result = await mermaid.render(chartIdRef.current, chart);
+        if (cancelled || !containerRef.current) return;
+        containerRef.current.innerHTML = result.svg;
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Mermaid rendering failed');
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [chart]);
+
+  if (error) {
+    return (
+      <div className="mermaid-fallback">
+        Mermaid render error: {error}
+        <pre>{chart}</pre>
+      </div>
+    );
+  }
+
+  return <div className="mermaid-diagram" ref={containerRef} />;
+}
+
+export default MermaidDiagram;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,6 +55,7 @@ import {
   SystemConfigRead,
   SystemStatus
 } from '../src/lib/types';
+import { MermaidDiagram } from './components/MermaidDiagram';
 
 const POLL_INTERVAL_MS = 1200;
 const META_STATUS_POLL_MAX_ATTEMPTS = 8;
@@ -93,52 +94,6 @@ type AgentImportResult = {
   skipped: number;
   errors: string[];
 };
-
-function MermaidDiagram({ chart }: { chart: string }) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const chartIdRef = useRef(`mermaid-${Math.random().toString(36).slice(2)}`);
-
-  useEffect(() => {
-    let cancelled = false;
-    setError(null);
-    const run = async () => {
-      const target = containerRef.current;
-      if (!target) return;
-      try {
-        const mod = await import('mermaid');
-        const mermaid = mod.default;
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: 'strict',
-          theme: 'neutral',
-          suppressErrorRendering: true
-        });
-        const result = await mermaid.render(chartIdRef.current, chart);
-        if (cancelled || !containerRef.current) return;
-        containerRef.current.innerHTML = result.svg;
-      } catch (err) {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Mermaid rendering failed');
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [chart]);
-
-  if (error) {
-    return (
-      <div className="mermaid-fallback">
-        Mermaid render error: {error}
-        <pre>{chart}</pre>
-      </div>
-    );
-  }
-
-  return <div className="mermaid-diagram" ref={containerRef} />;
-}
 
 function HomePageContent() {
   const [apiBase, setApiBaseState] = useState('');


### PR DESCRIPTION
## Summary

First structural extract from the 5,400-line \`page.tsx\`. Moves \`MermaidDiagram\` (45 lines, self-contained) to \`app/components/MermaidDiagram.tsx\`. Establishes \`app/components/\` as the home for subsequent extractions (Admin, System, Library, Agents panels) in P1.c/P1.d.

## Why this first

The Mermaid renderer has its own \`useState\`, \`useRef\`, \`useEffect\` and **zero coupling to the parent component's state cascade** (no shared refs, no prop drilling to fetchers). That makes it the lowest-risk starting extract — behavior is identical before/after.

## Test plan

- [x] Frontend \`bun run test --run\` — **43/43 passed**
- [x] Production build succeeds
- [x] Mermaid diagrams still render in the README preview (the component's only caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)