### PR TITLE
feat(frontend): collapse directive wall behind top-5 + disclosure (P2.b)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1483,6 +1483,29 @@ function HomePageContent() {
       });
   }, [metaReviewRun, metaCategoryFilter]);
   const metaSummary = metaReviewRun?.summary ?? null;
+  const [showAllDirectives, setShowAllDirectives] = useState(false);
+  // How many directive cards to render by default. Matches the cap on
+  // attention_points in the verdict summary so the two surfaces stay
+  // consistent: the top-N the system considers worth promoting are both
+  // reflected in the compact summary and the detailed cards below it.
+  const META_DIRECTIVE_DEFAULT_LIMIT = 5;
+  // Auto-expand the full directive list whenever the user has focused a
+  // specific directive (click, URL drill-down, keyboard) past the
+  // default window — the card needs to be in the DOM for
+  // scroll-into-view and the selected highlighting to have an effect.
+  const focusedIndex = focusedMetaCommentId
+    ? filteredMetaComments.findIndex((item) => item.id === focusedMetaCommentId)
+    : -1;
+  const hoveredIndex = hoveredMetaCommentId
+    ? filteredMetaComments.findIndex((item) => item.id === hoveredMetaCommentId)
+    : -1;
+  const focusRequiresExpansion =
+    focusedIndex >= META_DIRECTIVE_DEFAULT_LIMIT || hoveredIndex >= META_DIRECTIVE_DEFAULT_LIMIT;
+  const mustShowAllDirectives = showAllDirectives || focusRequiresExpansion;
+  const visibleMetaDirectives = mustShowAllDirectives
+    ? filteredMetaComments
+    : filteredMetaComments.slice(0, META_DIRECTIVE_DEFAULT_LIMIT);
+  const hiddenDirectiveCount = filteredMetaComments.length - visibleMetaDirectives.length;
 
   const activeCommentId = focusedCommentId ?? hoveredCommentId;
   const activeMetaCommentId = commentViewMode === 'meta' ? focusedMetaCommentId ?? hoveredMetaCommentId : null;
@@ -3116,7 +3139,7 @@ function HomePageContent() {
               {commentViewMode === 'meta' &&
                 !isMetaLoading &&
                 metaViewState === 'ready' &&
-                filteredMetaComments.map((metaComment, index) => {
+                visibleMetaDirectives.map((metaComment, index) => {
                   const topSource = metaComment.sources[0];
                   const pseudoColor = colorForPriority(metaComment.priority);
                   const isFloatingMetaActive =
@@ -3220,6 +3243,22 @@ function HomePageContent() {
                     </div>
                   );
                 })}
+              {commentViewMode === 'meta' &&
+                !isMetaLoading &&
+                metaViewState === 'ready' &&
+                (hiddenDirectiveCount > 0 || mustShowAllDirectives) &&
+                filteredMetaComments.length > META_DIRECTIVE_DEFAULT_LIMIT && (
+                  <button
+                    type="button"
+                    className="ghost-button meta-directive-toggle"
+                    onClick={() => setShowAllDirectives((prev) => !prev)}
+                    aria-expanded={mustShowAllDirectives}
+                  >
+                    {mustShowAllDirectives
+                      ? 'Hide secondary directives'
+                      : `Show ${hiddenDirectiveCount} more directives`}
+                  </button>
+                )}
             </div>
             {commentViewMode === 'individual' &&
               floatingComment &&

--- a/frontend/tests/metaDirectiveDisclosure.test.tsx
+++ b/frontend/tests/metaDirectiveDisclosure.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+let mockPathname = '/';
+let mockSearchParams = new URLSearchParams();
+
+function applyMockRoute(next: string) {
+  const parsed = new URL(next, 'http://localhost');
+  mockPathname = parsed.pathname;
+  mockSearchParams = new URLSearchParams(parsed.search);
+}
+
+const pushMock = vi.fn((next: string) => {
+  applyMockRoute(next);
+});
+const replaceMock = vi.fn((next: string) => {
+  applyMockRoute(next);
+});
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParams.get(key),
+    has: (key: string) => mockSearchParams.has(key),
+    toString: () => mockSearchParams.toString(),
+  }),
+}));
+
+import HomePage from '../app/page';
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeDirective(id: number, priority = 'medium') {
+  return {
+    id,
+    content: `Directive ${id} content goes here.`,
+    category: 'clarity',
+    priority,
+    impact: 'medium',
+    effort: 'medium',
+    confidence: 0.7,
+    why_now: null,
+    recommended_change: null,
+    verification_step: null,
+    status: 'open',
+    assignee: null,
+    due_at: null,
+    rank_score: 9 - id * 0.01,
+    start_offset: id * 10,
+    end_offset: id * 10 + 5,
+    order_index: id,
+    is_unsynthesized: false,
+    sources: [],
+  };
+}
+
+describe('meta directive disclosure', () => {
+  beforeEach(() => {
+    mockPathname = '/';
+    mockSearchParams = new URLSearchParams('doc=101');
+    pushMock.mockClear();
+    replaceMock.mockClear();
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        clear: () => {
+          store.clear();
+        },
+      },
+    });
+
+    const directives = Array.from({ length: 8 }, (_, i) => makeDirective(9500 + i));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/documents/library'))
+        return json([
+          {
+            id: 101,
+            title: 'Design Notes',
+            latest_version_id: 401,
+            latest_version_number: 1,
+            latest_version_created_at: new Date().toISOString(),
+            latest_review_status: 'completed',
+            latest_review_job_id: 501,
+          },
+        ]);
+      if (url.endsWith('/documents')) return json([]);
+      if (url.includes('/documents/101/versions')) {
+        return json([
+          {
+            id: 401,
+            document_id: 101,
+            version_label: 'v1',
+            content: 'Alpha beta gamma',
+            created_at: new Date().toISOString(),
+          },
+        ]);
+      }
+      if (url.includes('/documents/versions/401')) {
+        return json({
+          id: 401,
+          document_id: 101,
+          version_label: 'v1',
+          content: 'Alpha beta gamma',
+          created_at: new Date().toISOString(),
+        });
+      }
+      if (url.includes('/documents/101/history')) return json([]);
+      if (url.includes('/review-jobs') && method === 'GET') {
+        return json([
+          {
+            id: 501,
+            tenant_id: 'local-dev',
+            document_version_id: 401,
+            status: 'completed',
+            trigger: 'upload',
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            completed_at: new Date().toISOString(),
+            created_at: new Date().toISOString(),
+          },
+        ]);
+      }
+      if (url.includes('/comments')) return json([]);
+      if (url.includes('/personas')) return json([]);
+      if (url.includes('/status')) return json({ redis: { ok: true }, openai: { ok: true }, llm: { ok: true } });
+      if (url.includes('/meta-reviews/latest')) {
+        return json({
+          id: 900,
+          tenant_id: 'local-dev',
+          document_version_id: 401,
+          review_job_id: 501,
+          input_hash: 'hash',
+          status: 'completed',
+          is_synthesized: true,
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          error_message: null,
+          created_at: new Date().toISOString(),
+          summary: {
+            verdict: 'problems',
+            attention_points: directives.slice(0, 5).map((d) => ({
+              meta_comment_id: d.id,
+              location: 'Section',
+              reason: d.content,
+              priority: d.priority,
+              start_offset: d.start_offset,
+              end_offset: d.end_offset,
+              source_comment_ids: [],
+            })),
+            clean_sections: [],
+            clean_statement: 'No section is clean enough to skip yet.',
+          },
+          comments: directives,
+        });
+      }
+      return json({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders at most 5 directive cards by default and reveals the rest behind a toggle', async () => {
+    render(<HomePage />);
+
+    // Wait for meta mode to settle with directives loaded.
+    expect(
+      await screen.findByText('Verdict, top attention points, and clean sections.', {}, { timeout: 3000 }),
+    ).toBeTruthy();
+
+    // First 5 directive cards should be in the DOM.
+    await waitFor(() => {
+      expect(document.querySelectorAll('.comment-card[data-meta-id]').length).toBe(5);
+    });
+
+    // A disclosure button should advertise how many more there are.
+    const expandButton = await screen.findByRole('button', {
+      name: /Show 3 more directives/i,
+    });
+    expect(expandButton).toBeTruthy();
+
+    // Clicking expands the full list.
+    fireEvent.click(expandButton);
+    await waitFor(() => {
+      expect(document.querySelectorAll('.comment-card[data-meta-id]').length).toBe(8);
+    });
+
+    // And the button now says "Hide".
+    expect(
+      await screen.findByRole('button', { name: /Hide secondary directives/i }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

First shipped user-facing improvement in P2. Directly addresses the ownership review's #1 product complaint: the meta panel overloading reviewers with every directive, defeating the verdict's "top attention points" framing.

## Before

Meta panel rendered the full directive list as full-size cards below the verdict summary — typically 20–50 cards per review on real content. The verdict said "here are the top 5 attention points" while the UI below simultaneously screamed "here are all 42 individual directives, good luck."

## After

- **Default render: first 5 directive cards.** Matches the cap on \`attention_points\` in the verdict summary, so the top-N the system promotes is consistent across both surfaces.
- **Disclosure button** at the bottom: "Show N more directives" / "Hide secondary directives".
- **Auto-expand on focus**: clicking a hidden directive (via URL drill-down, keyboard, or source-comment jump) automatically expands the list so the card is actually in the DOM for scroll-into-view / highlight.

## What did not change

- Underlying data (meta run still stores every directive).
- Empty / loading / error / pending states.
- Floating card behavior.
- Summary panel (verdict + attention points + clean_sections).

## Test plan

- [x] New \`tests/metaDirectiveDisclosure.test.tsx\` — verifies the top-5 cap, the "Show N more" button text, and the full-list reveal on click.
- [x] Frontend \`bun run test --run\` — **47/47 passed** (46 existing + 1 new).
- [x] 5 consecutive full-suite reruns — 0 failures.
- [x] Production build succeeds.

## What's next in P2

- P2.d: test coverage for verdict thresholds + clean_sections (backend-only)
- P2.a: replace Python verdict rule with LLM-emitted verdict (the actual synthesis)
- P2.c: embedding-based directive dedupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)