### PR TITLE
feat(meta): LLM-synthesized verdict with bottom_line + top_blockers (P2.a)

### DIFF
--- a/backend/app/api/meta_reviews.py
+++ b/backend/app/api/meta_reviews.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -9,7 +10,9 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.deps import get_db, get_tenant_id
+from app.core.config import settings
 from app.db import models
+from app.reviews.llm_provider import LLMProviderError, generate_completion
 from app.reviews.meta_reviewer import (
     ensure_meta_review_run,
     normalize_meta_review_run_state,
@@ -21,6 +24,10 @@ from app.schemas.meta_review import (
     MetaReviewEnsureRequest,
     MetaReviewRunRead,
 )
+
+VALID_VERDICTS = {"clean", "review_needed", "problems"}
+LLM_VERDICT_MAX_COMMENTS = 10
+LLM_VERDICT_CONTENT_EXCERPT_CHARS = 1500
 
 router = APIRouter(prefix="/meta-reviews", tags=["meta-reviews"])
 logger = logging.getLogger(__name__)
@@ -217,6 +224,121 @@ def _clean_statement(verdict: str, clean_sections: list[str]) -> str:
     return "No section is clean enough to skip yet."
 
 
+def _llm_verdict_prompt(comments: list[models.MetaComment], content: str) -> str:
+    """Build the synthesis prompt for the go/no-go verdict pass.
+
+    The model sees: the top-N comments (priority + content), a short
+    excerpt of the document text, and a strict JSON-only contract. The
+    call is deliberately tiny — one sentence per directive, no sources,
+    no schema metadata — so it fits a fast short-context completion and
+    returns promptly even on large reviews.
+    """
+    excerpt = content.strip()[:LLM_VERDICT_CONTENT_EXCERPT_CHARS]
+    compact = [
+        {
+            "priority": comment.priority,
+            "impact": comment.impact,
+            "content": comment.content,
+        }
+        for comment in comments[:LLM_VERDICT_MAX_COMMENTS]
+    ]
+    return (
+        "You are the meta-reviewer's Adjudicator. Your job is to read "
+        "reviewer concerns about a document and decide a single go/no-go "
+        "verdict for the author.\n\n"
+        "Document excerpt (truncated if long):\n"
+        "---\n"
+        f"{excerpt}\n"
+        "---\n\n"
+        "Reviewer concerns (top ranked):\n"
+        f"{json.dumps(compact, indent=2)}\n\n"
+        "Return ONLY a JSON object with these exact keys — no prose, no "
+        "markdown, no commentary outside the JSON:\n"
+        "{\n"
+        '  "verdict": one of "clean" | "review_needed" | "problems",\n'
+        '  "bottom_line": one sentence (under 25 words) stating your '
+        "overall judgment in plain language,\n"
+        '  "top_blockers": array of up to 3 short blocker strings '
+        "(each under 15 words); empty array if the verdict is "
+        '"clean" or there are no blockers.\n'
+        "}\n\n"
+        "Rules for verdict:\n"
+        '- "clean" means no action needed; the document is ready.\n'
+        '- "review_needed" means quality improvements are warranted '
+        "but nothing blocks shipping.\n"
+        '- "problems" means the document has at least one issue that '
+        "should block shipping until addressed (factual error, "
+        "security/compliance risk, broken claim, critical gap, etc.)."
+    )
+
+
+def _parse_llm_verdict_response(raw: str) -> dict | None:
+    """Parse the LLM's JSON response into the verdict contract.
+
+    Returns None when the response is unparseable or missing required
+    fields; the caller falls back to the rule-based heuristic. We
+    tolerate leading/trailing whitespace and an optional ```json fence
+    since smaller models occasionally wrap despite the instructions.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        # Strip an opening fence and optional language tag, plus a closing fence.
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```\s*$", "", text)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    verdict = parsed.get("verdict")
+    if verdict not in VALID_VERDICTS:
+        return None
+    bottom_line = parsed.get("bottom_line")
+    if not isinstance(bottom_line, str) or not bottom_line.strip():
+        return None
+    raw_blockers = parsed.get("top_blockers", [])
+    if not isinstance(raw_blockers, list):
+        return None
+    top_blockers: list[str] = []
+    for item in raw_blockers[:3]:
+        if isinstance(item, str) and item.strip():
+            top_blockers.append(item.strip())
+    return {
+        "verdict": verdict,
+        "bottom_line": bottom_line.strip(),
+        "top_blockers": top_blockers,
+    }
+
+
+def _synthesize_llm_verdict(
+    comments: list[models.MetaComment], content: str
+) -> dict | None:
+    """Run the LLM verdict-synthesis pass; return None on any failure.
+
+    Callers compose this with the rule-based helper: if this returns
+    None the rule-based verdict still lights up the summary so the UI
+    never shows a blank panel when the provider is unreachable.
+    """
+    if not comments:
+        return None
+    if not getattr(settings, "META_VERDICT_USE_LLM", True):
+        return None
+    try:
+        raw = generate_completion(_llm_verdict_prompt(comments, content))
+    except LLMProviderError as exc:
+        logger.info("meta_llm_verdict_failed reason=provider_error detail=%s", exc)
+        return None
+    except Exception:
+        logger.exception("meta_llm_verdict_failed reason=unexpected")
+        return None
+    parsed = _parse_llm_verdict_response(raw or "")
+    if parsed is None:
+        logger.info("meta_llm_verdict_failed reason=parse_error")
+        return None
+    return parsed
+
+
 def _build_summary_payload(run: models.MetaReviewRun, content: str) -> dict | None:
     if run.status != "completed":
         return None
@@ -224,7 +346,23 @@ def _build_summary_payload(run: models.MetaReviewRun, content: str) -> dict | No
     comments = list(run.comments)
     sections = _build_sections(content)
     clean_sections = _clean_sections_for_comments(sections, comments)
-    verdict = _verdict_for_comments(comments)
+
+    # Try LLM synthesis first; fall back to the rule-based verdict if
+    # the provider is unavailable, times out, or returns malformed JSON.
+    # Attention points + clean sections come from the deterministic
+    # helpers either way so the UI stays stable across fallbacks.
+    llm_result = _synthesize_llm_verdict(comments, content)
+    if llm_result is not None:
+        verdict = llm_result["verdict"]
+        bottom_line: str | None = llm_result["bottom_line"]
+        top_blockers: list[str] = llm_result["top_blockers"]
+        synthesized_by_llm = True
+    else:
+        verdict = _verdict_for_comments(comments)
+        bottom_line = None
+        top_blockers = []
+        synthesized_by_llm = False
+
     attention_points = []
     for comment in comments[:5]:
         attention_points.append(
@@ -241,9 +379,12 @@ def _build_summary_payload(run: models.MetaReviewRun, content: str) -> dict | No
 
     return {
         "verdict": verdict,
+        "bottom_line": bottom_line,
+        "top_blockers": top_blockers,
         "attention_points": attention_points,
         "clean_sections": clean_sections,
         "clean_statement": _clean_statement(verdict, clean_sections),
+        "synthesized_by_llm": synthesized_by_llm,
     }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -132,6 +132,12 @@ class Settings(BaseSettings):
     TRUST_PROXY_HEADERS: bool = False
     PROXY_TRUSTED_IPS: str = "127.0.0.1"
     META_AUTO_SYNTHESIS_ENABLED: bool = True
+    # Enables the LLM-synthesized verdict pass that produces a
+    # bottom-line summary and top-blockers list alongside the rule-based
+    # verdict threshold. When False (or the provider fails), the summary
+    # still renders using the deterministic rule-based verdict so the UI
+    # stays usable in air-gapped / degraded scenarios.
+    META_VERDICT_USE_LLM: bool = True
     META_AGENT_NAME: str = "Meta Reviewer"
     META_AGENT_DESCRIPTION: str = "Synthesizes reviewer comments into ranked directives."
     META_AGENT_SYSTEM_PROMPT: str = (

--- a/backend/app/schemas/meta_review.py
+++ b/backend/app/schemas/meta_review.py
@@ -74,9 +74,20 @@ class MetaAttentionPointRead(BaseModel):
 
 class MetaReviewSummaryRead(BaseModel):
     verdict: MetaReviewVerdict
+    # One-sentence human-readable rationale for the verdict. Emitted by
+    # the LLM synthesis pass when available; None when the rule-based
+    # fallback runs (no LLM provider configured, provider down, etc.).
+    bottom_line: str | None = None
+    # Up to three short blocker summaries the LLM picked as the most
+    # critical issues driving the verdict, independent of attention_points
+    # which are ranked by score. Empty list in the fallback path.
+    top_blockers: list[str] = Field(default_factory=list)
     attention_points: list[MetaAttentionPointRead] = Field(default_factory=list)
     clean_sections: list[str] = Field(default_factory=list)
     clean_statement: str
+    # True when verdict + bottom_line + top_blockers were produced by an
+    # LLM synthesis pass; False when the rule-based fallback was used.
+    synthesized_by_llm: bool = False
 
 
 class MetaReviewRunRead(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,11 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 @pytest.fixture()
 def client(monkeypatch):
     monkeypatch.setattr(settings, "AUTH_MODE", "header")
+    # Default tests off the LLM verdict pass so the existing route
+    # integration tests do not reach out to a real OpenAI API. Tests
+    # that exercise the LLM verdict explicitly opt in and patch
+    # generate_completion themselves.
+    monkeypatch.setattr(settings, "META_VERDICT_USE_LLM", False)
     monkeypatch.setattr(
         "app.api.review_jobs.enqueue_review_job",
         lambda job_id, tenant_id: None,

--- a/backend/tests/test_meta_verdict_llm.py
+++ b/backend/tests/test_meta_verdict_llm.py
@@ -1,0 +1,201 @@
+"""Tests for the LLM-synthesized verdict path in meta_reviews.
+
+Exercises the three flows:
+1. Happy path — LLM returns a valid JSON contract → summary gets
+   bottom_line + top_blockers + synthesized_by_llm=True.
+2. Provider failure — generate_completion raises → summary falls back to
+   the rule-based verdict with bottom_line=None and
+   synthesized_by_llm=False.
+3. Malformed response — LLM returns garbage or wrong verdict token → same
+   graceful fallback as (2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+
+import pytest
+
+from app.api import meta_reviews as meta_reviews_api
+from app.core.config import settings
+
+
+@dataclass
+class FakeSource:
+    comment_id: int = 1
+
+
+@dataclass
+class FakeMetaComment:
+    id: int
+    content: str
+    priority: str = "high"
+    impact: str = "medium"
+    confidence: float = 0.7
+    start_offset: int = 0
+    end_offset: int = 10
+    sources: list[FakeSource] = field(default_factory=list)
+
+
+@dataclass
+class FakeRun:
+    status: str = "completed"
+    comments: list[FakeMetaComment] = field(default_factory=list)
+
+
+def _comment(id_: int = 1, priority: str = "high") -> FakeMetaComment:
+    return FakeMetaComment(
+        id=id_,
+        content=f"Comment {id_} raises a concern worth acting on.",
+        priority=priority,
+        impact="high",
+        confidence=0.85,
+        sources=[FakeSource(comment_id=id_ * 100)],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable_llm_verdict(monkeypatch):
+    # The shared conftest disables LLM verdict by default; re-enable it
+    # for the tests in this module so we exercise the LLM path directly.
+    monkeypatch.setattr(settings, "META_VERDICT_USE_LLM", True)
+
+
+def test_happy_path_llm_verdict_populates_bottom_line_and_blockers(monkeypatch):
+    llm_json = json.dumps(
+        {
+            "verdict": "problems",
+            "bottom_line": "Ship-blocking security claim in section 2 is unverified.",
+            "top_blockers": [
+                "Unverified token validation rule",
+                "Missing rate-limit numbers",
+            ],
+        }
+    )
+    monkeypatch.setattr(meta_reviews_api, "generate_completion", lambda _: llm_json)
+
+    run = FakeRun(comments=[_comment(1), _comment(2, priority="medium")])
+    payload = meta_reviews_api._build_summary_payload(run, content="# Intro\n\nBody paragraph.")
+
+    assert payload is not None
+    assert payload["verdict"] == "problems"
+    assert payload["bottom_line"] == "Ship-blocking security claim in section 2 is unverified."
+    assert payload["top_blockers"] == [
+        "Unverified token validation rule",
+        "Missing rate-limit numbers",
+    ]
+    assert payload["synthesized_by_llm"] is True
+    # Deterministic surfaces still come from the helpers.
+    assert len(payload["attention_points"]) == 2
+    assert payload["attention_points"][0]["meta_comment_id"] == 1
+
+
+def test_provider_error_falls_back_to_rule_based_verdict(monkeypatch):
+    from app.reviews.llm_provider import LLMProviderError
+
+    def fail(_prompt: str) -> str:
+        raise LLMProviderError("provider down")
+
+    monkeypatch.setattr(meta_reviews_api, "generate_completion", fail)
+
+    # One high-priority / high-impact / high-confidence comment → rule
+    # classifies as problems (see _verdict_for_comments).
+    run = FakeRun(comments=[_comment(1)])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    assert payload["verdict"] == "problems"
+    assert payload["bottom_line"] is None
+    assert payload["top_blockers"] == []
+    assert payload["synthesized_by_llm"] is False
+
+
+def test_malformed_json_response_falls_back(monkeypatch):
+    monkeypatch.setattr(
+        meta_reviews_api,
+        "generate_completion",
+        lambda _: "this is not json at all",
+    )
+
+    run = FakeRun(comments=[_comment(1, priority="medium")])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    # One medium-priority comment → rule verdict is review_needed.
+    assert payload["verdict"] == "review_needed"
+    assert payload["bottom_line"] is None
+    assert payload["synthesized_by_llm"] is False
+
+
+def test_invalid_verdict_token_falls_back(monkeypatch):
+    monkeypatch.setattr(
+        meta_reviews_api,
+        "generate_completion",
+        lambda _: json.dumps({"verdict": "meh", "bottom_line": "bad", "top_blockers": []}),
+    )
+
+    run = FakeRun(comments=[_comment(1)])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    assert payload["synthesized_by_llm"] is False
+
+
+def test_flag_disabled_skips_llm_path(monkeypatch):
+    # When META_VERDICT_USE_LLM is False the LLM code path must not be
+    # invoked at all — i.e. generate_completion should not be called.
+    monkeypatch.setattr(settings, "META_VERDICT_USE_LLM", False)
+    call_count = {"n": 0}
+
+    def counting(_prompt: str) -> str:
+        call_count["n"] += 1
+        return "{}"
+
+    monkeypatch.setattr(meta_reviews_api, "generate_completion", counting)
+
+    run = FakeRun(comments=[_comment(1)])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    assert payload["synthesized_by_llm"] is False
+    assert call_count["n"] == 0
+
+
+def test_response_wrapped_in_markdown_fence_is_still_parsed(monkeypatch):
+    fenced = "```json\n" + json.dumps(
+        {
+            "verdict": "review_needed",
+            "bottom_line": "Tighten phrasing in section 1.",
+            "top_blockers": [],
+        }
+    ) + "\n```"
+    monkeypatch.setattr(meta_reviews_api, "generate_completion", lambda _: fenced)
+
+    run = FakeRun(comments=[_comment(1, priority="medium")])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    assert payload["verdict"] == "review_needed"
+    assert payload["bottom_line"] == "Tighten phrasing in section 1."
+    assert payload["synthesized_by_llm"] is True
+
+
+def test_empty_comments_short_circuits_to_rule_clean_verdict(monkeypatch):
+    # LLM path should not be hit when there are no comments — the rule
+    # helper already returns "clean" deterministically.
+    call_count = {"n": 0}
+
+    def counting(_prompt: str) -> str:
+        call_count["n"] += 1
+        return "{}"
+
+    monkeypatch.setattr(meta_reviews_api, "generate_completion", counting)
+
+    run = FakeRun(comments=[])
+    payload = meta_reviews_api._build_summary_payload(run, content="Body.")
+
+    assert payload is not None
+    assert payload["verdict"] == "clean"
+    assert payload["synthesized_by_llm"] is False
+    assert call_count["n"] == 0

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2959,14 +2959,28 @@ function HomePageContent() {
                             : 'Review needed'}
                       </div>
                       <div className="meta-verdict-copy">
-                        {metaSummary.verdict === 'clean'
-                          ? 'No significant issues found.'
-                          : metaSummary.verdict === 'problems'
-                            ? 'Do not approve, send, or ship without fixing these.'
-                            : 'A few things are worth your attention.'}
+                        {metaSummary.bottom_line && metaSummary.bottom_line.trim().length > 0
+                          ? metaSummary.bottom_line
+                          : metaSummary.verdict === 'clean'
+                            ? 'No significant issues found.'
+                            : metaSummary.verdict === 'problems'
+                              ? 'Do not approve, send, or ship without fixing these.'
+                              : 'A few things are worth your attention.'}
                       </div>
                     </div>
                   </div>
+                  {metaSummary.top_blockers && metaSummary.top_blockers.length > 0 && (
+                    <div className="meta-summary-block">
+                      <div className="meta-summary-title">Top blockers</div>
+                      <ul className="meta-blocker-list">
+                        {metaSummary.top_blockers.map((blocker, index) => (
+                          <li key={`meta-blocker-${index}`} className="meta-blocker-item">
+                            {blocker}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                   {metaSummary.attention_points.length > 0 && (
                     <div className="meta-summary-block">
                       <div className="meta-summary-title">Top attention points</div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -263,9 +263,12 @@ export type MetaAttentionPointRead = {
 
 export type MetaReviewSummaryRead = {
   verdict: 'clean' | 'review_needed' | 'problems';
+  bottom_line?: string | null;
+  top_blockers?: string[];
   attention_points: MetaAttentionPointRead[];
   clean_sections: string[];
   clean_statement: string;
+  synthesized_by_llm?: boolean;
 };
 
 export type MetaReviewRunRead = {


### PR DESCRIPTION
## Summary

Replaces the pure rule-based go/no-go classifier with a real LLM synthesis pass. The ownership review identified this as the missing piece: the existing Python rule counted severities but never produced a human-language judgment the reviewer could read and act on.

## What changed

### Backend pipeline
- New \`_synthesize_llm_verdict\` pass sends the top-10 meta comments + a document excerpt to the LLM provider and parses a strict JSON contract: \`{verdict, bottom_line, top_blockers}\`.
- \`_build_summary_payload\` tries the LLM path first, falls back to the deterministic \`_verdict_for_comments\` rule on: provider error, malformed JSON, out-of-vocabulary verdict token, or when the feature flag is off.
- Attention points + clean sections stay deterministic so the UI is stable across fallbacks.

### Config
- New flag \`META_VERDICT_USE_LLM\` (default \`True\`). Operators can force rule-based in air-gapped / degraded environments. The test conftest defaults it to \`False\` so existing route-integration tests do not reach out to a real OpenAI API.

### Schema
- \`MetaReviewSummaryRead\` gains optional \`bottom_line\`, \`top_blockers\`, and \`synthesized_by_llm\` fields. All optional / default backward-compatible so older clients keep working.

### Frontend
- Verdict panel renders the LLM \`bottom_line\` in place of the canned per-verdict copy when available.
- New "Top blockers" block renders the LLM's 1–3 blocker summaries above the attention-points list.
- \`types.ts\` widened accordingly.

## Test plan

- [x] 7 new backend tests in \`tests/test_meta_verdict_llm.py\` — happy path, provider error fallback, malformed JSON fallback, invalid verdict-token fallback, feature-flag-off short-circuit, markdown-fenced response, empty-comments short-circuit.
- [x] Backend **133/133 passed** (104 existing + 22 P2.d + 7 new).
- [x] Frontend **47/47 passed** (stable across 5 full-suite reruns).
- [x] Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)