### PR TITLE
feat(meta): embedding-based directive dedupe with Jaccard fallback (P2.c)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -138,6 +138,14 @@ class Settings(BaseSettings):
     # still renders using the deterministic rule-based verdict so the UI
     # stays usable in air-gapped / degraded scenarios.
     META_VERDICT_USE_LLM: bool = True
+    # When True, meta-directive dedupe uses cosine similarity on
+    # embeddings of the directive content (plus the existing location /
+    # category boosts) instead of token-Jaccard. Catches semantic
+    # duplicates that share meaning but not words. Falls back to the
+    # Jaccard path on embedding-provider failure so dedupe always runs.
+    META_DEDUPE_USE_EMBEDDINGS: bool = True
+    META_DEDUPE_EMBEDDING_THRESHOLD: float = 0.85
+    OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-small"
     META_AGENT_NAME: str = "Meta Reviewer"
     META_AGENT_DESCRIPTION: str = "Synthesizes reviewer comments into ranked directives."
     META_AGENT_SYSTEM_PROMPT: str = (

--- a/backend/app/reviews/llm_provider.py
+++ b/backend/app/reviews/llm_provider.py
@@ -32,6 +32,38 @@ def generate_completion(prompt: str) -> str:
     raise LLMProviderError(f"Unsupported LLM provider: {settings.LLM_PROVIDER}")
 
 
+def generate_embeddings(texts: list[str]) -> list[list[float]]:
+    """Return one embedding vector per input text.
+
+    Only the OpenAI provider is supported today; Bedrock raises
+    LLMProviderError so callers can decide to fall back to non-embedding
+    logic. Callers MUST handle this exception — embeddings are an
+    optional optimization, not a hard dependency.
+    """
+    if not texts:
+        return []
+    provider = get_provider_name()
+    if provider != "openai":
+        raise LLMProviderError(
+            f"Embeddings not supported for provider: {settings.LLM_PROVIDER}"
+        )
+    client = get_openai_client()
+    try:
+        response = client.embeddings.create(
+            model=settings.OPENAI_EMBEDDING_MODEL,
+            input=texts,
+        )
+    except OpenAIError as exc:
+        raise LLMProviderError(str(exc)) from exc
+    # OpenAI returns results in the same order as input but expose the
+    # `index` field so we normalize to the input order explicitly.
+    ordered: list[list[float]] = [[] for _ in texts]
+    for item in response.data:
+        if 0 <= item.index < len(ordered):
+            ordered[item.index] = list(item.embedding)
+    return ordered
+
+
 def provider_health() -> dict[str, Any]:
     provider = get_provider_name()
     if provider == "openai":

--- a/backend/app/reviews/meta_reviewer.py
+++ b/backend/app/reviews/meta_reviewer.py
@@ -15,6 +15,7 @@ from app.db import models
 from app.reviews.llm_provider import (
     LLMProviderError,
     generate_completion,
+    generate_embeddings,
     get_model_label,
     get_provider_name,
 )
@@ -457,7 +458,28 @@ def _tokenize(value: str) -> set[str]:
     return {token for token in TOKEN_RE.findall((value or "").lower()) if len(token) > 2}
 
 
+def _cosine_similarity(left: list[float], right: list[float]) -> float:
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for a, b in zip(left, right):
+        dot += a * b
+        left_norm += a * a
+        right_norm += b * b
+    if left_norm <= 0 or right_norm <= 0:
+        return 0.0
+    return dot / ((left_norm**0.5) * (right_norm**0.5))
+
+
 def _directive_similarity(left: MetaDirectiveCandidate, right: MetaDirectiveCandidate) -> float:
+    """Token-Jaccard similarity.
+
+    Kept as the deterministic fallback when embeddings are disabled or
+    the provider is unavailable. Embedding-driven callers should use
+    _directive_similarity_with_embeddings instead.
+    """
     left_tokens = _tokenize(left.content)
     right_tokens = _tokenize(right.content)
     if not left_tokens or not right_tokens:
@@ -468,6 +490,26 @@ def _directive_similarity(left: MetaDirectiveCandidate, right: MetaDirectiveCand
         return 0.0
 
     text_score = len(overlap) / len(union)
+    location_span = max(left.end_offset, right.end_offset) - min(left.start_offset, right.start_offset)
+    near = 1.0 if location_span <= GROUP_ADJACENCY_CHARS else 0.0
+    same_category = 1.0 if left.category == right.category else 0.0
+    return (text_score * 0.7) + (near * 0.2) + (same_category * 0.1)
+
+
+def _directive_similarity_with_embedding(
+    left: MetaDirectiveCandidate,
+    right: MetaDirectiveCandidate,
+    left_embedding: list[float],
+    right_embedding: list[float],
+) -> float:
+    """Cosine-on-embeddings text score, keeping location + category boosts.
+
+    Embedding similarity captures semantic duplicates (same meaning, new
+    wording) that token-Jaccard misses. Location proximity and category
+    match still contribute so two identical-sounding directives on
+    unrelated sections don't collapse into one.
+    """
+    text_score = _cosine_similarity(left_embedding, right_embedding)
     location_span = max(left.end_offset, right.end_offset) - min(left.start_offset, right.start_offset)
     near = 1.0 if location_span <= GROUP_ADJACENCY_CHARS else 0.0
     same_category = 1.0 if left.category == right.category else 0.0
@@ -503,22 +545,99 @@ def _merge_directives(primary: MetaDirectiveCandidate, duplicate: MetaDirectiveC
     return primary
 
 
+def _maybe_compute_embeddings(
+    candidates: list[MetaDirectiveCandidate],
+) -> dict[int, list[float]] | None:
+    """Return embeddings keyed by candidate index, or None on failure.
+
+    None means "use the Jaccard path" — that's the deliberate
+    fallback when the provider is not OpenAI, is unreachable, or
+    returns a mismatched count. The dedupe caller never fails because
+    of embeddings; it only skips the upgrade.
+    """
+    if not getattr(settings, "META_DEDUPE_USE_EMBEDDINGS", False):
+        return None
+    try:
+        texts = [candidate.content or "" for candidate in candidates]
+        vectors = generate_embeddings(texts)
+    except LLMProviderError as exc:
+        logger.info("meta_embedding_dedupe_skipped reason=provider_error detail=%s", exc)
+        return None
+    except Exception:
+        logger.exception("meta_embedding_dedupe_skipped reason=unexpected")
+        return None
+    if len(vectors) != len(candidates):
+        logger.info(
+            "meta_embedding_dedupe_skipped reason=length_mismatch expected=%s got=%s",
+            len(candidates),
+            len(vectors),
+        )
+        return None
+    embeddings: dict[int, list[float]] = {}
+    for idx, vector in enumerate(vectors):
+        if vector:
+            embeddings[idx] = vector
+    # Require at least half the candidates to have non-empty vectors; below
+    # that the dedupe quality drops below what Jaccard offers.
+    if len(embeddings) < max(1, len(candidates) // 2):
+        logger.info(
+            "meta_embedding_dedupe_skipped reason=too_many_empty filled=%s total=%s",
+            len(embeddings),
+            len(candidates),
+        )
+        return None
+    return embeddings
+
+
 def dedupe_directives(candidates: list[MetaDirectiveCandidate]) -> list[MetaDirectiveCandidate]:
     if not candidates:
         return []
 
+    # Use a stable id->candidate mapping so we can reference the
+    # precomputed embedding for each candidate, even as the deduped
+    # list is reordered/merged during the sweep.
+    sorted_candidates = sorted(
+        candidates, key=lambda item: (item.order_index, -item.rank_score)
+    )
+    embeddings_by_index: dict[int, list[float]] | None = _maybe_compute_embeddings(
+        sorted_candidates
+    )
+    use_embeddings = embeddings_by_index is not None
+
+    # Map each candidate object (by identity) to its embedding so that
+    # _merge_directives mutating `primary` does not break the lookup.
+    candidate_embeddings: dict[int, list[float]] = {}
+    if embeddings_by_index is not None:
+        for idx, candidate in enumerate(sorted_candidates):
+            embedding = embeddings_by_index.get(idx)
+            if embedding:
+                candidate_embeddings[id(candidate)] = embedding
+
     deduped: list[MetaDirectiveCandidate] = []
-    threshold = settings.META_GLOBAL_DEDUPE_THRESHOLD
-    for candidate in sorted(candidates, key=lambda item: (item.order_index, -item.rank_score)):
+    if use_embeddings:
+        threshold = settings.META_DEDUPE_EMBEDDING_THRESHOLD
+    else:
+        threshold = settings.META_GLOBAL_DEDUPE_THRESHOLD
+
+    for candidate in sorted_candidates:
+        candidate_embedding = candidate_embeddings.get(id(candidate))
         duplicate_idx = None
         for idx, existing in enumerate(deduped):
-            if _directive_similarity(candidate, existing) >= threshold:
+            existing_embedding = candidate_embeddings.get(id(existing))
+            if use_embeddings and candidate_embedding and existing_embedding:
+                score = _directive_similarity_with_embedding(
+                    candidate, existing, candidate_embedding, existing_embedding
+                )
+            else:
+                score = _directive_similarity(candidate, existing)
+            if score >= threshold:
                 duplicate_idx = idx
                 break
         if duplicate_idx is None:
             deduped.append(candidate)
         else:
-            deduped[duplicate_idx] = _merge_directives(deduped[duplicate_idx], candidate)
+            merged = _merge_directives(deduped[duplicate_idx], candidate)
+            deduped[duplicate_idx] = merged
 
     deduped.sort(key=lambda item: (-item.rank_score, item.start_offset, item.order_index))
     for index, candidate in enumerate(deduped):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,6 +27,10 @@ def client(monkeypatch):
     # that exercise the LLM verdict explicitly opt in and patch
     # generate_completion themselves.
     monkeypatch.setattr(settings, "META_VERDICT_USE_LLM", False)
+    # Also keep the embedding-driven dedupe off so existing tests do not
+    # hit the embedding provider. Tests exercising the embedding path
+    # opt in and patch generate_embeddings themselves.
+    monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", False)
     monkeypatch.setattr(
         "app.api.review_jobs.enqueue_review_job",
         lambda job_id, tenant_id: None,

--- a/backend/tests/test_meta_embedding_dedupe.py
+++ b/backend/tests/test_meta_embedding_dedupe.py
@@ -1,0 +1,235 @@
+"""Tests for the embedding-based dedupe path in meta_reviewer.
+
+Token-Jaccard misses semantic duplicates like "improve clarity of
+section 3" vs. "section 3 needs clearer writing" — they share few
+tokens. Embeddings close that gap when the provider is available,
+while preserving the Jaccard fallback for air-gapped / degraded
+deployments.
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+
+import pytest
+
+from app.core.config import settings
+from app.reviews import meta_reviewer
+from app.reviews.meta_reviewer import (
+    MetaDirectiveCandidate,
+    _cosine_similarity,
+    dedupe_directives,
+)
+
+
+def _candidate(
+    content: str,
+    *,
+    category: str = "clarity",
+    priority: str = "medium",
+    start_offset: int = 0,
+    end_offset: int = 50,
+    order_index: int = 0,
+    rank_score: float = 1.0,
+) -> MetaDirectiveCandidate:
+    return MetaDirectiveCandidate(
+        content=content,
+        category=category,
+        priority=priority,
+        impact="medium",
+        effort="medium",
+        confidence=0.7,
+        why_now=None,
+        recommended_change=None,
+        verification_step=None,
+        status="open",
+        assignee=None,
+        due_at=None,
+        rank_score=rank_score,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        order_index=order_index,
+        contributing_reviewers=[],
+        source_comments=[],
+        is_unsynthesized=False,
+    )
+
+
+def _unit(v: list[float]) -> list[float]:
+    norm = sqrt(sum(x * x for x in v))
+    return [x / norm for x in v] if norm else v
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_score_one(self) -> None:
+        v = [1.0, 2.0, 3.0]
+        assert _cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_score_zero(self) -> None:
+        assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_empty_inputs_are_safe(self) -> None:
+        assert _cosine_similarity([], [1.0]) == 0.0
+        assert _cosine_similarity([1.0], []) == 0.0
+
+    def test_length_mismatch_returns_zero(self) -> None:
+        assert _cosine_similarity([1.0, 2.0], [1.0]) == 0.0
+
+
+class TestDedupeEmbeddingPath:
+    def test_semantically_similar_directives_merge_under_embeddings(self, monkeypatch) -> None:
+        """Two directives that share meaning but not tokens should merge
+        when embeddings say they are the same thing.
+
+        With Jaccard these would survive as duplicates because the
+        0.72 threshold requires heavy token overlap.
+        """
+        monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", True)
+
+        # Vectors chosen so the two content strings are ~0.99 cosine —
+        # clearly above the 0.85 embedding threshold — while having
+        # near-zero token overlap in their content strings.
+        vec_a = _unit([1.0, 0.1, 0.05])
+        vec_b = _unit([0.99, 0.11, 0.06])
+
+        monkeypatch.setattr(
+            meta_reviewer,
+            "generate_embeddings",
+            lambda texts: [vec_a, vec_b],
+        )
+
+        first = _candidate(
+            "Section 3 prose density overwhelms the reader.",
+            start_offset=100,
+            end_offset=200,
+            order_index=0,
+        )
+        second = _candidate(
+            "Loosen up the middle body — too dense for casual reading.",
+            start_offset=110,
+            end_offset=210,
+            order_index=1,
+        )
+
+        result = dedupe_directives([first, second])
+
+        assert len(result) == 1, "semantically identical directives must merge"
+
+    def test_semantically_distinct_directives_stay_separate(self, monkeypatch) -> None:
+        """Two directives on different topics should remain as two
+        separate meta comments even when they share a section.
+        """
+        monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", True)
+
+        # Orthogonal embeddings — low cosine.
+        monkeypatch.setattr(
+            meta_reviewer,
+            "generate_embeddings",
+            lambda texts: [_unit([1.0, 0.0, 0.0]), _unit([0.0, 1.0, 0.0])],
+        )
+
+        first = _candidate(
+            "Clarify the API authentication policy.",
+            category="technical",
+            start_offset=0,
+            end_offset=50,
+            order_index=0,
+        )
+        second = _candidate(
+            "Add a typography guideline to the style section.",
+            category="style",
+            start_offset=0,
+            end_offset=50,
+            order_index=1,
+        )
+
+        result = dedupe_directives([first, second])
+
+        assert len(result) == 2
+
+
+class TestDedupeFallback:
+    def test_embedding_provider_failure_falls_back_to_jaccard(self, monkeypatch) -> None:
+        """When the embedding provider raises, dedupe must not crash —
+        it falls back to the existing Jaccard path so pipelines in
+        air-gapped / degraded environments still produce output.
+        """
+        from app.reviews.llm_provider import LLMProviderError
+
+        monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", True)
+
+        def failing(_texts: list[str]) -> list[list[float]]:
+            raise LLMProviderError("provider down")
+
+        monkeypatch.setattr(meta_reviewer, "generate_embeddings", failing)
+
+        # Two heavy token-overlap directives would merge under Jaccard
+        # at the 0.72 threshold — proves we actually ran the fallback.
+        # Content chosen so Jaccard similarity is clearly above 0.72
+        # (4/5 tokens shared = 0.8 Jaccard → 0.56 text-weighted + 0.2
+        # near + 0.1 category = 0.86 > 0.72).
+        first = _candidate(
+            "Clarify opening paragraph introduction.",
+            start_offset=0,
+            end_offset=60,
+            order_index=0,
+        )
+        second = _candidate(
+            "Clarify opening paragraph introduction clearly.",
+            start_offset=0,
+            end_offset=60,
+            order_index=1,
+        )
+
+        result = dedupe_directives([first, second])
+
+        assert len(result) == 1
+
+    def test_feature_flag_off_uses_jaccard(self, monkeypatch) -> None:
+        call_count = {"n": 0}
+
+        def counting(_texts: list[str]) -> list[list[float]]:
+            call_count["n"] += 1
+            return []
+
+        monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", False)
+        monkeypatch.setattr(meta_reviewer, "generate_embeddings", counting)
+
+        first = _candidate("The opening paragraph confuses the reader.", order_index=0)
+        second = _candidate("The opening paragraph feels unclear to readers.", order_index=1)
+
+        dedupe_directives([first, second])
+
+        assert call_count["n"] == 0
+
+    def test_empty_embedding_for_blank_content_does_not_crash(self, monkeypatch) -> None:
+        """If the provider returns an empty vector for a candidate we
+        skip pairwise embedding checks for that candidate rather than
+        treating the empty vector as "similar to everything".
+        """
+        monkeypatch.setattr(settings, "META_DEDUPE_USE_EMBEDDINGS", True)
+
+        # Both non-empty so the path stays on embeddings; first vector
+        # is aligned with second so they should merge, third is empty
+        # (bad input) which falls back to Jaccard for its comparisons.
+        monkeypatch.setattr(
+            meta_reviewer,
+            "generate_embeddings",
+            lambda texts: [_unit([1.0, 0.1]), _unit([0.99, 0.12]), []],
+        )
+
+        first = _candidate("Tighten the intro.", order_index=0)
+        second = _candidate("Make the intro crisper.", order_index=1)
+        third = _candidate(
+            "Wholly unrelated direction about the appendix footer styling.",
+            start_offset=1000,
+            end_offset=1100,
+            category="style",
+            order_index=2,
+        )
+
+        result = dedupe_directives([first, second, third])
+
+        # First two merge, third stays separate — no crash on the empty
+        # embedding for the third candidate.
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Replaces the token-Jaccard similarity in meta-directive dedupe with embedding cosine similarity, and keeps the Jaccard path as the deterministic fallback when the provider is unavailable.

## Why

The ownership review traced the residual "overload" in the meta panel to phantom duplicates that the 0.72 token-Jaccard threshold let through — pairs like "improve clarity of section 3" and "section 3 needs clearer writing" are semantic twins with near-zero token overlap, so Jaccard does not merge them even though the reviewer sees a noisy meta output.

## Pipeline

- New \`generate_embeddings(texts)\` helper in \`llm_provider\` calls the OpenAI embeddings API. Bedrock raises \`LLMProviderError\` so callers can fall back.
- \`_directive_similarity_with_embedding\` uses cosine on content embeddings as the text score, keeping the existing location-proximity (0.2) and category-match (0.1) boosts so two identically-phrased directives on unrelated sections still don't collapse.
- \`dedupe_directives\` precomputes embeddings once per sweep. It falls back to the deterministic Jaccard path when:
  - the provider fails,
  - the response length does not match the candidate count, or
  - more than half the candidates come back with empty vectors.
- A meta run never crashes on embedding issues — the worst case is the original dedupe quality.

## Config (all optional, sensible defaults)

- \`META_DEDUPE_USE_EMBEDDINGS\` (default \`True\`) — operators can force Jaccard in air-gapped / cost-sensitive deployments.
- \`META_DEDUPE_EMBEDDING_THRESHOLD\` (default \`0.85\`).
- \`OPENAI_EMBEDDING_MODEL\` (default \`text-embedding-3-small\`).

## Test plan

- [x] 9 new tests in \`tests/test_meta_embedding_dedupe.py\`:
  - \`_cosine_similarity\` edge cases (identical, orthogonal, empty, length mismatch).
  - Semantic merge under embeddings (vectors chosen so cosine ≫ threshold while content strings have ~0 token overlap).
  - Semantically distinct directives stay separate.
  - Provider-error fallback to Jaccard.
  - Feature-flag-off short-circuit (no provider call).
  - Empty-vector safety on a single candidate.
- [x] Test conftest defaults \`META_DEDUPE_USE_EMBEDDINGS=False\` so existing route-integration tests don't reach a real embeddings API.
- [x] Backend **142/142 passed** (133 existing + 9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced directive deduplication with improved semantic matching algorithm for more accurate identification of similar content.
  
* **Configuration**
  * Added new settings to customize deduplication behavior with optimized default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->